### PR TITLE
feat: exposing FlowStatus for the triggered flows.

### DIFF
--- a/API.md
+++ b/API.md
@@ -657,9 +657,9 @@ Check whether the given construct is a Resource.
 | <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.arn">arn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.arn">arn</a></code> | <code>string</code> | The ARN of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.name">name</a></code> | <code>string</code> | The name of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.FlowBase.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | The type of the flow. |
 
 ---
 
@@ -714,6 +714,8 @@ public readonly arn: string;
 
 - *Type:* string
 
+The ARN of the flow.
+
 ---
 
 ##### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-appflow.FlowBase.property.name"></a>
@@ -724,6 +726,8 @@ public readonly name: string;
 
 - *Type:* string
 
+The name of the flow.
+
 ---
 
 ##### `type`<sup>Required</sup> <a name="type" id="@cdklabs/cdk-appflow.FlowBase.property.type"></a>
@@ -733,6 +737,8 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+The type of the flow.
 
 ---
 
@@ -1766,9 +1772,9 @@ Check whether the given construct is a Resource.
 | <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.arn">arn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.arn">arn</a></code> | <code>string</code> | The ARN of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.name">name</a></code> | <code>string</code> | The name of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.OnDemandFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | The type of the flow. |
 
 ---
 
@@ -1823,6 +1829,8 @@ public readonly arn: string;
 
 - *Type:* string
 
+The ARN of the flow.
+
 ---
 
 ##### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-appflow.OnDemandFlow.property.name"></a>
@@ -1833,6 +1841,8 @@ public readonly name: string;
 
 - *Type:* string
 
+The name of the flow.
+
 ---
 
 ##### `type`<sup>Required</sup> <a name="type" id="@cdklabs/cdk-appflow.OnDemandFlow.property.type"></a>
@@ -1842,6 +1852,8 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+The type of the flow.
 
 ---
 
@@ -2085,9 +2097,9 @@ Check whether the given construct is a Resource.
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.arn">arn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.arn">arn</a></code> | <code>string</code> | The ARN of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.name">name</a></code> | <code>string</code> | The name of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.OnEventFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | The type of the flow. |
 
 ---
 
@@ -2142,6 +2154,8 @@ public readonly arn: string;
 
 - *Type:* string
 
+The ARN of the flow.
+
 ---
 
 ##### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-appflow.OnEventFlow.property.name"></a>
@@ -2152,6 +2166,8 @@ public readonly name: string;
 
 - *Type:* string
 
+The name of the flow.
+
 ---
 
 ##### `type`<sup>Required</sup> <a name="type" id="@cdklabs/cdk-appflow.OnEventFlow.property.type"></a>
@@ -2161,6 +2177,8 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+The type of the flow.
 
 ---
 
@@ -2385,9 +2403,9 @@ Check whether the given construct is a Resource.
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.arn">arn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.arn">arn</a></code> | <code>string</code> | The ARN of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.name">name</a></code> | <code>string</code> | The name of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | The type of the flow. |
 
 ---
 
@@ -2442,6 +2460,8 @@ public readonly arn: string;
 
 - *Type:* string
 
+The ARN of the flow.
+
 ---
 
 ##### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-appflow.OnScheduleFlow.property.name"></a>
@@ -2452,6 +2472,8 @@ public readonly name: string;
 
 - *Type:* string
 
+The name of the flow.
+
 ---
 
 ##### `type`<sup>Required</sup> <a name="type" id="@cdklabs/cdk-appflow.OnScheduleFlow.property.type"></a>
@@ -2461,6 +2483,8 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+The type of the flow.
 
 ---
 
@@ -4125,12 +4149,14 @@ public readonly credentials: ISecret;
 
 - *Implements:* <a href="#@cdklabs/cdk-appflow.IFlow">IFlow</a>
 
+A base class for triggered flows.
+
 #### Initializers <a name="Initializers" id="@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer"></a>
 
 ```typescript
 import { TriggeredFlowBase } from '@cdklabs/cdk-appflow'
 
-new TriggeredFlowBase(scope: Construct, id: string, props: FlowBaseProps, autoActivate?: boolean)
+new TriggeredFlowBase(scope: Construct, id: string, props: FlowBaseProps)
 ```
 
 | **Name** | **Type** | **Description** |
@@ -4138,7 +4164,6 @@ new TriggeredFlowBase(scope: Construct, id: string, props: FlowBaseProps, autoAc
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer.parameter.props">props</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowBaseProps">FlowBaseProps</a></code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer.parameter.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -4157,12 +4182,6 @@ new TriggeredFlowBase(scope: Construct, id: string, props: FlowBaseProps, autoAc
 ##### `props`<sup>Required</sup> <a name="props" id="@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer.parameter.props"></a>
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowBaseProps">FlowBaseProps</a>
-
----
-
-##### `autoActivate`<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.TriggeredFlowBase.Initializer.parameter.autoActivate"></a>
-
-- *Type:* boolean
 
 ---
 
@@ -4348,9 +4367,9 @@ Check whether the given construct is a Resource.
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.arn">arn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.arn">arn</a></code> | <code>string</code> | The ARN of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.name">name</a></code> | <code>string</code> | The name of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBase.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | The type of the flow. |
 
 ---
 
@@ -4405,6 +4424,8 @@ public readonly arn: string;
 
 - *Type:* string
 
+The ARN of the flow.
+
 ---
 
 ##### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-appflow.TriggeredFlowBase.property.name"></a>
@@ -4415,6 +4436,8 @@ public readonly name: string;
 
 - *Type:* string
 
+The name of the flow.
+
 ---
 
 ##### `type`<sup>Required</sup> <a name="type" id="@cdklabs/cdk-appflow.TriggeredFlowBase.property.type"></a>
@@ -4424,6 +4447,8 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+The type of the flow.
 
 ---
 
@@ -6100,7 +6125,7 @@ const onEventFlowProps: OnEventFlowProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | The status to set on the flow. |
 
 ---
 
@@ -6196,7 +6221,7 @@ public readonly validations: IValidation[];
 
 ##### ~~`autoActivate`~~<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.OnEventFlowProps.property.autoActivate"></a>
 
-- *Deprecated:* . Use active instead
+- *Deprecated:* . This property is deprecated and will be removed in a future release. Use {@link status} instead
 
 ```typescript
 public readonly autoActivate: boolean;
@@ -6213,6 +6238,10 @@ public readonly status: FlowStatus;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
+
+The status to set on the flow.
+
+Use this over {@link autoActivate}.
 
 ---
 
@@ -6240,7 +6269,7 @@ const onScheduleFlowProps: OnScheduleFlowProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | The status to set on the flow. |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.pullConfig">pullConfig</a></code> | <code><a href="#@cdklabs/cdk-appflow.DataPullConfig">DataPullConfig</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.schedule">schedule</a></code> | <code>aws-cdk-lib.aws_events.Schedule</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.scheduleProperties">scheduleProperties</a></code> | <code><a href="#@cdklabs/cdk-appflow.ScheduleProperties">ScheduleProperties</a></code> | *No description.* |
@@ -6339,7 +6368,7 @@ public readonly validations: IValidation[];
 
 ##### ~~`autoActivate`~~<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.OnScheduleFlowProps.property.autoActivate"></a>
 
-- *Deprecated:* . Use active instead
+- *Deprecated:* . This property is deprecated and will be removed in a future release. Use {@link status} instead
 
 ```typescript
 public readonly autoActivate: boolean;
@@ -6356,6 +6385,10 @@ public readonly status: FlowStatus;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
+
+The status to set on the flow.
+
+Use this over {@link autoActivate}.
 
 ---
 
@@ -8538,7 +8571,7 @@ const triggeredFlowBaseProps: TriggeredFlowBaseProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | The status to set on the flow. |
 
 ---
 
@@ -8634,7 +8667,7 @@ public readonly validations: IValidation[];
 
 ##### ~~`autoActivate`~~<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.autoActivate"></a>
 
-- *Deprecated:* . Use active instead
+- *Deprecated:* . This property is deprecated and will be removed in a future release. Use {@link status} instead
 
 ```typescript
 public readonly autoActivate: boolean;
@@ -8651,6 +8684,10 @@ public readonly status: FlowStatus;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
+
+The status to set on the flow.
+
+Use this over {@link autoActivate}.
 
 ---
 
@@ -12063,9 +12100,9 @@ public onRunStarted(id: string, options?: OnEventOptions): Rule
 | <code><a href="#@cdklabs/cdk-appflow.IFlow.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#@cdklabs/cdk-appflow.IFlow.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#@cdklabs/cdk-appflow.IFlow.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@cdklabs/cdk-appflow.IFlow.property.arn">arn</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.IFlow.property.name">name</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-appflow.IFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.IFlow.property.arn">arn</a></code> | <code>string</code> | The ARN of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.IFlow.property.name">name</a></code> | <code>string</code> | The name of the flow. |
+| <code><a href="#@cdklabs/cdk-appflow.IFlow.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | The type of the flow. |
 
 ---
 
@@ -12120,6 +12157,8 @@ public readonly arn: string;
 
 - *Type:* string
 
+The ARN of the flow.
+
 ---
 
 ##### `name`<sup>Required</sup> <a name="name" id="@cdklabs/cdk-appflow.IFlow.property.name"></a>
@@ -12130,6 +12169,8 @@ public readonly name: string;
 
 - *Type:* string
 
+The name of the flow.
+
 ---
 
 ##### `type`<sup>Required</sup> <a name="type" id="@cdklabs/cdk-appflow.IFlow.property.type"></a>
@@ -12139,6 +12180,8 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+The type of the flow.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -4931,6 +4931,7 @@ const flowBaseProps: FlowBaseProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.FlowBaseProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.FlowBaseProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.FlowBaseProps.property.type">type</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.FlowBaseProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.FlowBaseProps.property.triggerConfig">triggerConfig</a></code> | <code><a href="#@cdklabs/cdk-appflow.TriggerConfig">TriggerConfig</a></code> | *No description.* |
 
 ---
@@ -5032,6 +5033,16 @@ public readonly type: FlowType;
 ```
 
 - *Type:* <a href="#@cdklabs/cdk-appflow.FlowType">FlowType</a>
+
+---
+
+##### `status`<sup>Optional</sup> <a name="status" id="@cdklabs/cdk-appflow.FlowBaseProps.property.status"></a>
+
+```typescript
+public readonly status: FlowStatus;
+```
+
+- *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
 
 ---
 
@@ -6089,6 +6100,7 @@ const onEventFlowProps: OnEventFlowProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnEventFlowProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
 
 ---
 
@@ -6182,13 +6194,25 @@ public readonly validations: IValidation[];
 
 ---
 
-##### `autoActivate`<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.OnEventFlowProps.property.autoActivate"></a>
+##### ~~`autoActivate`~~<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.OnEventFlowProps.property.autoActivate"></a>
+
+- *Deprecated:* . Use active instead
 
 ```typescript
 public readonly autoActivate: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+##### `status`<sup>Optional</sup> <a name="status" id="@cdklabs/cdk-appflow.OnEventFlowProps.property.status"></a>
+
+```typescript
+public readonly status: FlowStatus;
+```
+
+- *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
 
 ---
 
@@ -6216,6 +6240,7 @@ const onScheduleFlowProps: OnScheduleFlowProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.pullConfig">pullConfig</a></code> | <code><a href="#@cdklabs/cdk-appflow.DataPullConfig">DataPullConfig</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.schedule">schedule</a></code> | <code>aws-cdk-lib.aws_events.Schedule</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.OnScheduleFlowProps.property.scheduleProperties">scheduleProperties</a></code> | <code><a href="#@cdklabs/cdk-appflow.ScheduleProperties">ScheduleProperties</a></code> | *No description.* |
@@ -6312,13 +6337,25 @@ public readonly validations: IValidation[];
 
 ---
 
-##### `autoActivate`<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.OnScheduleFlowProps.property.autoActivate"></a>
+##### ~~`autoActivate`~~<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.OnScheduleFlowProps.property.autoActivate"></a>
+
+- *Deprecated:* . Use active instead
 
 ```typescript
 public readonly autoActivate: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+##### `status`<sup>Optional</sup> <a name="status" id="@cdklabs/cdk-appflow.OnScheduleFlowProps.property.status"></a>
+
+```typescript
+public readonly status: FlowStatus;
+```
+
+- *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
 
 ---
 
@@ -8501,6 +8538,7 @@ const triggeredFlowBaseProps: TriggeredFlowBaseProps = { ... }
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.transforms">transforms</a></code> | <code><a href="#@cdklabs/cdk-appflow.ITransform">ITransform</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.validations">validations</a></code> | <code><a href="#@cdklabs/cdk-appflow.IValidation">IValidation</a>[]</code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.autoActivate">autoActivate</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.status">status</a></code> | <code><a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a></code> | *No description.* |
 
 ---
 
@@ -8594,13 +8632,25 @@ public readonly validations: IValidation[];
 
 ---
 
-##### `autoActivate`<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.autoActivate"></a>
+##### ~~`autoActivate`~~<sup>Optional</sup> <a name="autoActivate" id="@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.autoActivate"></a>
+
+- *Deprecated:* . Use active instead
 
 ```typescript
 public readonly autoActivate: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+##### `status`<sup>Optional</sup> <a name="status" id="@cdklabs/cdk-appflow.TriggeredFlowBaseProps.property.status"></a>
+
+```typescript
+public readonly status: FlowStatus;
+```
+
+- *Type:* <a href="#@cdklabs/cdk-appflow.FlowStatus">FlowStatus</a>
 
 ---
 
@@ -12336,6 +12386,27 @@ The AppFlow type of the connector that this source is implemented for.
 
 
 ##### `INCREMENTAL` <a name="INCREMENTAL" id="@cdklabs/cdk-appflow.DataPullMode.INCREMENTAL"></a>
+
+---
+
+
+### FlowStatus <a name="FlowStatus" id="@cdklabs/cdk-appflow.FlowStatus"></a>
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@cdklabs/cdk-appflow.FlowStatus.ACTIVE">ACTIVE</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-appflow.FlowStatus.SUSPENDED">SUSPENDED</a></code> | *No description.* |
+
+---
+
+##### `ACTIVE` <a name="ACTIVE" id="@cdklabs/cdk-appflow.FlowStatus.ACTIVE"></a>
+
+---
+
+
+##### `SUSPENDED` <a name="SUSPENDED" id="@cdklabs/cdk-appflow.FlowStatus.SUSPENDED"></a>
 
 ---
 

--- a/src/core/flows/flow-base.ts
+++ b/src/core/flows/flow-base.ts
@@ -51,6 +51,11 @@ export enum FlowType {
   SCHEDULED = 'Scheduled'
 }
 
+export enum FlowStatus {
+  ACTIVE = 'Active',
+  SUSPENDED = 'Suspended'
+}
+
 export enum DataPullMode {
   COMPLETE = 'Complete',
   INCREMENTAL = 'Incremental'
@@ -103,6 +108,7 @@ export interface FlowProps {
 export interface FlowBaseProps extends FlowProps {
   readonly type: FlowType;
   readonly triggerConfig?: TriggerConfig;
+  readonly status?: FlowStatus;
 }
 
 export abstract class FlowBase extends Resource implements IFlow {
@@ -133,6 +139,7 @@ export abstract class FlowBase extends Resource implements IFlow {
     this.name = props.name || id;
     const resource = new CfnFlow(this, id, {
       flowName: this.name,
+      flowStatus: props.status,
       triggerConfig: {
         triggerType: props.type,
         triggerProperties: props.triggerConfig

--- a/src/core/flows/flow-base.ts
+++ b/src/core/flows/flow-base.ts
@@ -16,29 +16,45 @@ import { IDestination } from '../vertices/destination';
 import { ISource } from '../vertices/source';
 
 export interface IFlow extends IResource {
+  /**
+   * The ARN of the flow.
+   */
   readonly arn: string;
+
+  /**
+   * The name of the flow
+   */
   readonly name: string;
+
+  /**
+   * The type of the flow.
+   */
   readonly type: FlowType;
 
   onRunStarted(id: string, options?: OnEventOptions): Rule;
 
   onRunCompleted(id: string, options?: OnEventOptions): Rule;
+
   /**
    * @internal
    */
   _addMapping(mapping: IMapping): IFlow;
+
   /**
    * @internal
    */
   _addValidation(validator: IValidation): IFlow;
+
   /**
    * @internal
    */
   _addTransform(transform: ITransform): IFlow;
+
   /**
    * @internal
    */
   _addFilter(filter: IFilter): IFlow;
+
   /**
    * @internal
    */
@@ -113,9 +129,19 @@ export interface FlowBaseProps extends FlowProps {
 
 export abstract class FlowBase extends Resource implements IFlow {
 
+  /**
+   * The ARN of the flow.
+   */
   public readonly arn: string;
+
+  /**
+   * The type of the flow.
+   */
   public readonly type: FlowType;
 
+  /**
+   * The name of the flow.
+   */
   public readonly name: string;
 
   private readonly mappings: CfnFlow.TaskProperty[] = [];

--- a/src/core/flows/on-event-flow.ts
+++ b/src/core/flows/on-event-flow.ts
@@ -15,7 +15,8 @@ export class OnEventFlow extends TriggeredFlowBase implements IFlow {
     super(scope, id, {
       ...props,
       type: FlowType.EVENT,
-    }, props.autoActivate);
+      status: TriggeredFlowBase.setStatus(props.autoActivate, props.status),
+    });
   }
 
   public onDeactivated(id: string, options: OnEventOptions = {}) {

--- a/src/core/flows/on-schedule-flow.ts
+++ b/src/core/flows/on-schedule-flow.ts
@@ -18,6 +18,7 @@ export class OnScheduleFlow extends TriggeredFlowBase implements IFlow {
     super(scope, id, {
       ...props,
       type: FlowType.SCHEDULED,
+      status: TriggeredFlowBase.setStatus(props.autoActivate, props.status),
       triggerConfig: {
         properties: {
           schedule: props.schedule,
@@ -25,7 +26,7 @@ export class OnScheduleFlow extends TriggeredFlowBase implements IFlow {
           properties: props.scheduleProperties,
         },
       },
-    }, props.autoActivate);
+    });
   }
 
   public onDeactivated(id: string, options: OnEventOptions = {}) {

--- a/src/core/flows/triggered-flow-base.ts
+++ b/src/core/flows/triggered-flow-base.ts
@@ -3,47 +3,50 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { OnEventOptions, Rule } from 'aws-cdk-lib/aws-events';
-import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
-import { FlowBase, FlowBaseProps, FlowProps, IFlow } from './flow-base';
+import { FlowBase, FlowBaseProps, FlowProps, FlowStatus, IFlow } from './flow-base';
 
 export interface TriggeredFlowBaseProps extends FlowProps {
+  /**
+   * The status to set on the flow. Use this over {@link autoActivate}.
+   */
+  readonly status?: FlowStatus;
+  /**
+   * @deprecated. This property is deprecated and will be removed in a future release. Use {@link status} instead
+   */
   readonly autoActivate?: boolean;
 }
 
+/**
+ * A base class for triggered flows.
+ */
 export abstract class TriggeredFlowBase extends FlowBase implements IFlow {
 
-  constructor(scope: Construct, id: string, props: FlowBaseProps, autoActivate?: boolean) {
-    super(scope, id, props);
-
-    if (autoActivate) {
-      const activatorId = `${id}Activator`;
-
-      // TODO: this is too basic. test it more to identify any potential errors/issues
-      const activator = new AwsCustomResource(scope, activatorId, {
-        onCreate: {
-          service: 'Appflow',
-          action: 'startFlow',
-          parameters: {
-            flowName: this.name,
-          },
-          physicalResourceId: PhysicalResourceId.of(activatorId),
-        },
-        onDelete: {
-          service: 'Appflow',
-          action: 'stopFlow',
-          parameters: {
-            flowName: this.name,
-          },
-        },
-        policy: AwsCustomResourcePolicy.fromSdkCalls({
-          resources: AwsCustomResourcePolicy.ANY_RESOURCE,
-        }),
-      });
-
-      activator.node.addDependency(this);
+  /**
+   *
+   * @param autoActivate - a boolean value indicating whether to automatically activate the flow.
+   * @param status - a {@link FlowStatus} value indicating the status to set on the flow.
+   * @returns
+   */
+  protected static setStatus(autoActivate?: boolean, status?: FlowStatus): FlowStatus | undefined {
+    if (autoActivate !== undefined && status !== undefined) {
+      throw new Error('Cannot specify both autoActivate and status');
     }
+
+    return autoActivate !== undefined ?
+      (autoActivate ? FlowStatus.ACTIVE : FlowStatus.SUSPENDED) :
+      (status !== undefined ? status : undefined);
+  }
+  /**
+   *
+   * @param scope
+   * @param id
+   * @param props
+   */
+  constructor(scope: Construct, id: string, props: FlowBaseProps) {
+    super(scope, id, props);
   }
 
   public abstract onDeactivated(id: string, options?: OnEventOptions): Rule;
+
 }

--- a/test/core/flows/on-event-flow.test.ts
+++ b/test/core/flows/on-event-flow.test.ts
@@ -176,6 +176,7 @@ describe('OnEventFlow', () => {
 
     template.hasResource('AWS::AppFlow::Flow', {
       Properties: {
+        FlowStatus: 'Suspended',
         DestinationFlowConfigList: [
           {
             ConnectorType: 'EventBridge',

--- a/test/core/flows/on-event-flow.test.ts
+++ b/test/core/flows/on-event-flow.test.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
-import { OnEventFlow, SalesforceSource, EventBridgeDestination, EventSources, Mapping, SalesforceConnectorProfile } from '../../../src';
+import { OnEventFlow, SalesforceSource, EventBridgeDestination, EventSources, Mapping, SalesforceConnectorProfile, FlowStatus } from '../../../src';
 
 describe('OnEventFlow', () => {
   test.each([{
@@ -30,7 +30,7 @@ describe('OnEventFlow', () => {
       source: source,
       destination: destination,
       mappings: [Mapping.mapAll()],
-      autoActivate: true,
+      status: FlowStatus.ACTIVE,
     });
 
     flow.onDeactivated('OnDeactivated', namedRules ? {
@@ -72,6 +72,7 @@ describe('OnEventFlow', () => {
           },
         ],
         FlowName: 'OnEventFlow',
+        FlowStatus: 'Active',
         SourceFlowConfig: {
           ConnectorProfileName: 'appflow-tester',
           ConnectorType: 'Salesforce',
@@ -148,20 +149,6 @@ describe('OnEventFlow', () => {
       },
       State: 'ENABLED',
     });
-
-    template.resourceCountIs('Custom::AWS', 1);
-
-    template.hasResourceProperties('Custom::AWS', {
-      ServiceToken: {
-        'Fn::GetAtt': [
-          'AWS679f53fac002430cb0da5b7982bd22872D164C4C',
-          'Arn',
-        ],
-      },
-      Create: '{"service":"Appflow","action":"startFlow","parameters":{"flowName":"OnEventFlow"},"physicalResourceId":{"id":"OnEventFlowActivator"}}',
-      Delete: '{"service":"Appflow","action":"stopFlow","parameters":{"flowName":"OnEventFlow"}}',
-      InstallLatestAwsSdk: true,
-    });
   });
 
   test('autoactivated flow without status and deactivation listeners renders flow definition only', () => {
@@ -182,7 +169,7 @@ describe('OnEventFlow', () => {
       source: source,
       destination: destination,
       mappings: [Mapping.mapAll()],
-      autoActivate: false,
+      status: FlowStatus.SUSPENDED,
     });
 
     const template = Template.fromStack(stack);

--- a/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.assets.json
@@ -79,20 +79,7 @@
         }
       }
     },
-    "f9346b940b724b094a16ca051c017799995fa93df6da38a0539bf7c000fee50a": {
-      "source": {
-        "path": "asset.f9346b940b724b094a16ca051c017799995fa93df6da38a0539bf7c000fee50a",
-        "packaging": "zip"
-      },
-      "destinations": {
-        "current_account-current_region": {
-          "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f9346b940b724b094a16ca051c017799995fa93df6da38a0539bf7c000fee50a.zip",
-          "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
-        }
-      }
-    },
-    "70e9e81a17e28b416e6cddd53c6f664013051489338e6fb4049fc03220fd5b32": {
+    "593c27ba9998e04fb75a5b15e6f87386ea622fd825ad3003bc96380f0567da22": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -100,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "70e9e81a17e28b416e6cddd53c6f664013051489338e6fb4049fc03220fd5b32.json",
+          "objectKey": "593c27ba9998e04fb75a5b15e6f87386ea622fd825ad3003bc96380f0567da22.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.template.json
+++ b/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.template.json
@@ -576,7 +576,8 @@
       }
      },
      "TriggerType": "Scheduled"
-    }
+    },
+    "FlowStatus": "Active"
    },
    "DependsOn": [
     "OnScheduleFlowUpdater39178314",
@@ -830,121 +831,6 @@
    "DependsOn": [
     "comamazonawscdkcustomresourcesflowtimeproviderframeworkonEventServiceRoleDefaultPolicyDE524CE6",
     "comamazonawscdkcustomresourcesflowtimeproviderframeworkonEventServiceRole2DC53640"
-   ]
-  },
-  "OnScheduleFlowActivatorEF04E46F": {
-   "Type": "Custom::AWS",
-   "Properties": {
-    "ServiceToken": {
-     "Fn::GetAtt": [
-      "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-      "Arn"
-     ]
-    },
-    "Create": "{\"service\":\"Appflow\",\"action\":\"startFlow\",\"parameters\":{\"flowName\":\"OnScheduleFlow\"},\"physicalResourceId\":{\"id\":\"OnScheduleFlowActivator\"}}",
-    "Delete": "{\"service\":\"Appflow\",\"action\":\"stopFlow\",\"parameters\":{\"flowName\":\"OnScheduleFlow\"}}",
-    "InstallLatestAwsSdk": true
-   },
-   "DependsOn": [
-    "OnScheduleFlowcaptureOnDeactivatedF7603006",
-    "OnScheduleFlowcaptureOnRunCompletedB9E179F4",
-    "OnScheduleFlow9A474F3B",
-    "OnScheduleFlowActivatorCustomResourcePolicyEE06504E"
-   ],
-   "UpdateReplacePolicy": "Delete",
-   "DeletionPolicy": "Delete"
-  },
-  "OnScheduleFlowActivatorCustomResourcePolicyEE06504E": {
-   "Type": "AWS::IAM::Policy",
-   "Properties": {
-    "PolicyDocument": {
-     "Statement": [
-      {
-       "Action": "appflow:StartFlow",
-       "Effect": "Allow",
-       "Resource": "*"
-      },
-      {
-       "Action": "appflow:StopFlow",
-       "Effect": "Allow",
-       "Resource": "*"
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "PolicyName": "OnScheduleFlowActivatorCustomResourcePolicyEE06504E",
-    "Roles": [
-     {
-      "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
-     }
-    ]
-   },
-   "DependsOn": [
-    "OnScheduleFlowcaptureOnDeactivatedF7603006",
-    "OnScheduleFlowcaptureOnRunCompletedB9E179F4",
-    "OnScheduleFlow9A474F3B"
-   ]
-  },
-  "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": {
-   "Type": "AWS::IAM::Role",
-   "Properties": {
-    "AssumeRolePolicyDocument": {
-     "Statement": [
-      {
-       "Action": "sts:AssumeRole",
-       "Effect": "Allow",
-       "Principal": {
-        "Service": "lambda.amazonaws.com"
-       }
-      }
-     ],
-     "Version": "2012-10-17"
-    },
-    "ManagedPolicyArns": [
-     {
-      "Fn::Join": [
-       "",
-       [
-        "arn:",
-        {
-         "Ref": "AWS::Partition"
-        },
-        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-       ]
-      ]
-     }
-    ]
-   }
-  },
-  "AWS679f53fac002430cb0da5b7982bd22872D164C4C": {
-   "Type": "AWS::Lambda::Function",
-   "Properties": {
-    "Code": {
-     "S3Bucket": {
-      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
-     },
-     "S3Key": "f9346b940b724b094a16ca051c017799995fa93df6da38a0539bf7c000fee50a.zip"
-    },
-    "Role": {
-     "Fn::GetAtt": [
-      "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-      "Arn"
-     ]
-    },
-    "Handler": "index.handler",
-    "Runtime": {
-     "Fn::FindInMap": [
-      "DefaultCrNodeVersionMap",
-      {
-       "Ref": "AWS::Region"
-      },
-      "value"
-     ]
-    },
-    "Timeout": 120
-   },
-   "DependsOn": [
-    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2"
    ]
   }
  },

--- a/test/integ/onschedule-s3-to-salesforce.integ.ts
+++ b/test/integ/onschedule-s3-to-salesforce.integ.ts
@@ -20,6 +20,7 @@ import {
   Transform,
   WriteOperation,
   SalesforceConnectorProfile,
+  FlowStatus,
 } from '../../src';
 
 const app = new App({
@@ -83,7 +84,7 @@ const flow = new OnScheduleFlow(stack, 'OnScheduleFlow', {
   scheduleProperties: {
     startTime: new Date(Date.parse('2024-01-01')),
   },
-  autoActivate: true,
+  status: FlowStatus.ACTIVE,
 });
 
 flow.node.addDependency(deployment);


### PR DESCRIPTION
With this PR the library uses the new [FlowStatus](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-flow.html#cfn-appflow-flow-flowstatus) field for activating/deactivating a triggered flow. 

It deprecates the use of [a custom resource](https://github.com/cdklabs/cdk-appflow/blob/a252fa11780da4b75ff0b1016199e561db874d13/src/core/flows/triggered-flow-base.ts#L23) and thus will result in changes to the generated template (less resources) with no change in the functionality.