### PR TITLE
fix: fix microsoftsharepointonline object schema

### DIFF
--- a/API.md
+++ b/API.md
@@ -6220,22 +6220,9 @@ const microsoftSharepointOnlineObject: MicrosoftSharepointOnlineObject = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.drives">drives</a></code> | <code>string[]</code> | An array of Microsoft Sharepoint Online site drives from which the documents are to be retrieved. |
 | <code><a href="#@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.site">site</a></code> | <code>string</code> | The Microsoft Sharepoint Online site from which the documents are to be retrieved. |
-
----
-
-##### `drives`<sup>Required</sup> <a name="drives" id="@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.drives"></a>
-
-```typescript
-public readonly drives: string[];
-```
-
-- *Type:* string[]
-
-An array of Microsoft Sharepoint Online site drives from which the documents are to be retrieved.
-
-Note: each drive requires full name starting with 'drives/'
+| <code><a href="#@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.drives">drives</a></code> | <code>string[]</code> | An array of Microsoft Sharepoint Online site drives from which the documents are to be retrieved. |
+| <code><a href="#@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.entities">entities</a></code> | <code>string[]</code> | An array of Microsoft Sharepoint Online site entities from which the documents are to be retrieved. |
 
 ---
 
@@ -6252,6 +6239,43 @@ The Microsoft Sharepoint Online site from which the documents are to be retrieve
 Note: requires full name starting with 'sites/'
 
 ---
+
+##### ~~`drives`~~<sup>Optional</sup> <a name="drives" id="@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.drives"></a>
+
+- *Deprecated:* . This property is deprecated and will be removed in a future release. Use {@link entities} instead
+
+```typescript
+public readonly drives: string[];
+```
+
+- *Type:* string[]
+
+An array of Microsoft Sharepoint Online site drives from which the documents are to be retrieved.
+
+Note: each drive requires full name starting with 'drives/'
+
+---
+
+##### `entities`<sup>Optional</sup> <a name="entities" id="@cdklabs/cdk-appflow.MicrosoftSharepointOnlineObject.property.entities"></a>
+
+```typescript
+public readonly entities: string[];
+```
+
+- *Type:* string[]
+
+An array of Microsoft Sharepoint Online site entities from which the documents are to be retrieved.
+
+Note: each entity requires full name starting with 'drives/' followed by driveID and optional '/items/' followed by itemID
+
+---
+
+*Example*
+
+```typescript
+: 'drives/${driveID}/items/${itemID}'
+```
+
 
 ### MicrosoftSharepointOnlineRefreshTokenGrantFlow <a name="MicrosoftSharepointOnlineRefreshTokenGrantFlow" id="@cdklabs/cdk-appflow.MicrosoftSharepointOnlineRefreshTokenGrantFlow"></a>
 

--- a/src/microsoftsharepointonline/source.ts
+++ b/src/microsoftsharepointonline/source.ts
@@ -26,8 +26,18 @@ export interface MicrosoftSharepointOnlineObject {
    * An array of Microsoft Sharepoint Online site drives from which the documents are to be retrieved.
    *
    * Note: each drive requires full name starting with 'drives/'
+   * @deprecated. This property is deprecated and will be removed in a future release. Use {@link entities} instead
    */
-  readonly drives: string[];
+  readonly drives?: string[];
+
+  /**
+   * An array of Microsoft Sharepoint Online site entities from which the documents are to be retrieved.
+   *
+   * Note: each entity requires full name starting with 'drives/' followed by driveID and optional '/items/' followed by itemID
+   * @example: 'drives/${driveID}'
+   * @example: 'drives/${driveID}/items/${itemID}'
+   */
+  readonly entities?: string[];
 }
 
 /**
@@ -65,15 +75,20 @@ export class MicrosoftSharepointOnlineSource implements ISource {
 
   private buildSourceConnectorProperties(): CfnFlow.SourceConnectorPropertiesProperty {
 
-    if (this.props.object.drives.length < 1) {
-      throw new Error('At least one drive must be specified');
+    if (this.props.object.entities && this.props.object.drives) {
+      throw new Error('Only one of the properties entities or drives should be specified');
+    }
+
+    const entities = this.props.object.entities ?? this.props.object.drives ?? [];
+    if (entities.length < 1) {
+      throw new Error('At least one entity must be specified');
     }
 
     return {
       customConnector: {
         entityName: this.props.object.site,
         customProperties: {
-          subEntities: `["${Fn.join('","', this.props.object.drives)}"]`,
+          subEntities: `["${Fn.join('","', entities)}"]`,
         },
       },
     };

--- a/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.ts
+++ b/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.ts
@@ -34,7 +34,7 @@ const source = new MicrosoftSharepointOnlineSource({
   apiVersion: MicrosoftSharepointOnlineApiVersion.V1,
   object: {
     site: secret.secretValueFromJson('site').toString(),
-    drives: [secret.secretValueFromJson('drive').toString()],
+    entities: [secret.secretValueFromJson('drive').toString()],
   },
 });
 

--- a/test/microsoftsharepointonline/source.test.ts
+++ b/test/microsoftsharepointonline/source.test.ts
@@ -24,7 +24,7 @@ describe('MicrosoftSharepointOnlineSource', () => {
       profile: MicrosoftSharepointOnlineConnectorProfile.fromConnectionProfileName(stack, 'TestProfile', 'dummy-profile'),
       object: {
         site: 'sites/dummysite.sharepoint.com,3f42g340-bc23-4a31-b7e5-722e57c39cb8,5bbc39fb-2b17-423b-a007-40ca508389a5',
-        drives: ['drives/b!fcPDltwTLSougEJuDFjE?U5qHuXbkzlvSaA5oNoMW4tB0y6mebcx9m-ckwA9KtKE'],
+        entities: ['drives/b!fcPDltwTLSougEJuDFjE?U5qHuXbkzlvSaA5oNoMW4tB0y6mebcx9m-ckwA9KtKE'],
       },
       apiVersion: MicrosoftSharepointOnlineApiVersion.V1,
     });
@@ -42,7 +42,7 @@ describe('MicrosoftSharepointOnlineSource', () => {
       profile: MicrosoftSharepointOnlineConnectorProfile.fromConnectionProfileName(stack, 'TestProfile', 'dummy-profile'),
       object: {
         site: 'sites/dummysite.sharepoint.com,3f42g340-bc23-4a31-b7e5-722e57c39cb8,5bbc39fb-2b17-423b-a007-40ca508389a5',
-        drives: ['drives/b!fcPDltwTLSougEJuDFjE?U5qHuXbkzlvSaA5oNoMW4tB0y6mebcx9m-ckwA9KtKE'],
+        entities: ['drives/b!fcPDltwTLSougEJuDFjE?U5qHuXbkzlvSaA5oNoMW4tB0y6mebcx9m-ckwA9KtKE'],
       },
       apiVersion: MicrosoftSharepointOnlineApiVersion.V1,
     });
@@ -128,7 +128,7 @@ describe('MicrosoftSharepointOnlineSource', () => {
       profile: profile,
       object: {
         site: 'sites/dummysite.sharepoint.com,3f42g340-bc23-4a31-b7e5-722e57c39cb8,5bbc39fb-2b17-423b-a007-40ca508389a5',
-        drives: ['drives/b!fcPDltwTLSougEJuDFjE?U5qHuXbkzlvSaA5oNoMW4tB0y6mebcx9m-ckwA9KtKE'],
+        entities: ['drives/b!fcPDltwTLSougEJuDFjE?U5qHuXbkzlvSaA5oNoMW4tB0y6mebcx9m-ckwA9KtKE'],
       },
       apiVersion: MicrosoftSharepointOnlineApiVersion.V1,
     });


### PR DESCRIPTION
Fixes #27 
This PR updates microsoftsharepointonline source object property by deprecating `drives` and introducing `entities` with examples how to use it with both drives and items defined. 

- microsoftsharepointonline source object.drives is deprecated
- microsoftsharepointonline source object.entities is introduced
- microsoftsharepointonline source unit test is updated
- microsoftsharepointonline integration test is updated