### PR TITLE
feat: making MS Sharepoint Online refresh token optional

### DIFF
--- a/src/microsoftdynamics365/profile.ts
+++ b/src/microsoftdynamics365/profile.ts
@@ -95,6 +95,7 @@ export class MicrosoftDynamics365ConnectorProfile extends ConnectorProfileBase {
         oauth2: {
           // INFO: when using Refresh Token Grant Flow - access token property is required
           accessToken: properties.oAuth.accessToken?.unsafeUnwrap() ?? 'dummyAccessToken',
+          // INFO: when passing only an access token - this value is still required
           refreshToken: properties.oAuth.flow?.refreshTokenGrant.refreshToken?.unsafeUnwrap() ?? 'dummyRefreshToken',
           clientId: properties.oAuth.flow?.refreshTokenGrant.clientId?.unsafeUnwrap(),
           clientSecret: properties.oAuth.flow?.refreshTokenGrant.clientSecret?.unsafeUnwrap(),

--- a/src/microsoftsharepointonline/profile.ts
+++ b/src/microsoftsharepointonline/profile.ts
@@ -91,7 +91,8 @@ export class MicrosoftSharepointOnlineConnectorProfile extends ConnectorProfileB
         oauth2: {
           // INFO: when using Refresh Token Grant Flow - access token property is required
           accessToken: properties.oAuth.accessToken?.unsafeUnwrap() ?? 'dummyAccessToken',
-          refreshToken: properties.oAuth.flow?.refreshTokenGrant.refreshToken?.unsafeUnwrap(),
+          // INFO: when passing only an access token - this value is still required
+          refreshToken: properties.oAuth.flow?.refreshTokenGrant.refreshToken?.unsafeUnwrap() ?? 'dummyRefreshToken',
           clientId: properties.oAuth.flow?.refreshTokenGrant.clientId?.unsafeUnwrap(),
           clientSecret: properties.oAuth.flow?.refreshTokenGrant.clientSecret?.unsafeUnwrap(),
         },


### PR DESCRIPTION
Although it is possible for Amazon AppFlow to work with the Microsoft Sharepoint Online connector only passing the `accessToken` - the CloudFormation template still requires any value for the `refreshToken`. 

This PR updates the implementation of the Microsoft Sharepoint Online Connector Profile to amend for the empty `refreshToken` so the deployment is not failing.