### PR TITLE
fix: remove extra space for GoogleBigQuery ConnectorLabel

### DIFF
--- a/src/googlebigquery/type.ts
+++ b/src/googlebigquery/type.ts
@@ -19,6 +19,6 @@ export class GoogleBigQueryConnectorType extends ConnectorType {
   private static actualInstance: ConnectorType;
 
   constructor() {
-    super('Google BigQuery', true);
+    super('GoogleBigQuery', true);
   }
 }

--- a/test/googlebigquery/profile.test.ts
+++ b/test/googlebigquery/profile.test.ts
@@ -33,7 +33,7 @@ describe('GoogleBigQueryConnectorProfile', () => {
       ConnectionMode: 'Public',
       ConnectorProfileName: 'TestProfile',
       ConnectorType: 'CustomConnector',
-      ConnectorLabel: 'Google BigQuery',
+      ConnectorLabel: 'GoogleBigQuery',
       ConnectorProfileConfig: {
         ConnectorProfileCredentials: {
           CustomConnector: {
@@ -83,7 +83,7 @@ describe('GoogleBigQueryConnectorProfile', () => {
       ConnectionMode: 'Public',
       ConnectorProfileName: 'TestProfile',
       ConnectorType: 'CustomConnector',
-      ConnectorLabel: 'Google BigQuery',
+      ConnectorLabel: 'GoogleBigQuery',
       ConnectorProfileConfig: {
         ConnectorProfileCredentials: {
           CustomConnector: {
@@ -193,7 +193,7 @@ describe('GoogleBigQueryConnectorProfile', () => {
         ConnectionMode: 'Public',
         ConnectorProfileName: 'TestProfile',
         ConnectorType: 'CustomConnector',
-        ConnectorLabel: 'Google BigQuery',
+        ConnectorLabel: 'GoogleBigQuery',
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
             CustomConnector: {

--- a/test/googlebigquery/source.test.ts
+++ b/test/googlebigquery/source.test.ts
@@ -146,7 +146,7 @@ describe('GoogleBigQuerySource', () => {
       ConnectionMode: 'Public',
       ConnectorProfileName: 'TestProfile',
       ConnectorType: 'CustomConnector',
-      ConnectorLabel: 'Google BigQuery',
+      ConnectorLabel: 'GoogleBigQuery',
       ConnectorProfileConfig: {
         ConnectorProfileCredentials: {
           CustomConnector: {


### PR DESCRIPTION
### Problem:
When deploying with the current code, the following CloudFormation template is created.
```
{
  "Resources": {
    "GoogleBigQueryConnector***": {
      "Type": "AWS::AppFlow::ConnectorProfile",
      "Properties": {
        "ConnectionMode": "Public",
        "ConnectorLabel": "Google BigQuery",
...
```

And it fails with the CreateConnectorProfile API.
```
// excerpt CloudTrail Event
    "eventSource": "appflow.amazonaws.com",
    "eventName": "CreateConnectorProfile",
    "userAgent": "cloudformation.amazonaws.com",
    "errorCode": "ValidationException",
    "requestParameters": {
        "connectorType": "CustomConnector",
...
        "connectorLabel": "Google BigQuery"
    },
    "responseElements": {
        "message": "1 validation error detected: Value 'Google BigQuery' at 'connectorLabel' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9][\\w!@.-]+"
    }, 
```


### My investigation:
This error is caused by the specification of the CreateConnectorProfile API, and the reason is that spaces cannot be used in "[connectorLabel](https://docs.aws.amazon.com/appflow/1.0/APIReference/API_CreateConnectorProfile.html#API_CreateConnectorProfile_RequestSyntax)".

Removing this space allowed the deployment to succeed.