### PR TITLE
feat!: changing physical resource naming convention

### DIFF
--- a/src/core/flows/flow-base.ts
+++ b/src/core/flows/flow-base.ts
@@ -36,6 +36,7 @@ export interface IFlow extends IResource {
 
   onRunCompleted(id: string, options?: OnEventOptions): Rule;
 
+
   /**
    * Creates a metric to report the number of flow runs started.
    * @param options
@@ -95,17 +96,17 @@ export interface IFlow extends IResource {
 export enum FlowType {
   EVENT = 'Event',
   ON_DEMAND = 'OnDemand',
-  SCHEDULED = 'Scheduled',
+  SCHEDULED = 'Scheduled'
 }
 
 export enum FlowStatus {
   ACTIVE = 'Active',
-  SUSPENDED = 'Suspended',
+  SUSPENDED = 'Suspended'
 }
 
 export enum DataPullMode {
   COMPLETE = 'Complete',
-  INCREMENTAL = 'Incremental',
+  INCREMENTAL = 'Incremental'
 }
 
 export interface DataPullConfig {
@@ -158,6 +159,7 @@ export interface FlowBaseProps extends FlowProps {
 }
 
 export abstract class FlowBase extends Resource implements IFlow {
+
   /**
    * The ARN of the flow.
    */
@@ -199,32 +201,23 @@ export abstract class FlowBase extends Resource implements IFlow {
 
     this.type = props.type;
 
-    this._projectionFilter = this.initProjectionFilter(
-      props.source.connectorType,
-    );
+    this._projectionFilter = this.initProjectionFilter(props.source.connectorType);
 
     const resource = new CfnFlow(this, id, {
       flowName: this.physicalName,
       flowStatus: props.status,
       triggerConfig: {
         triggerType: props.type,
-        triggerProperties:
-          props.triggerConfig &&
-          props.triggerConfig.properties &&
-          this.buildTriggerProperties(
-            scope,
-            id,
-            props.triggerConfig.properties,
-          ),
+        triggerProperties: props.triggerConfig
+          && props.triggerConfig.properties
+          && this.buildTriggerProperties(scope, id, props.triggerConfig.properties),
       },
       kmsArn: props.key?.keyArn,
       metadataCatalogConfig: Lazy.any({ produce: () => this._catalogMetadata }),
       description: props.description,
       sourceFlowConfig: {
         ...props.source.bind(this),
-        incrementalPullConfig: this.buildIncrementalPullConfig(
-          props.triggerConfig,
-        ),
+        incrementalPullConfig: this.buildIncrementalPullConfig(props.triggerConfig),
       },
       // NOTE: currently only a single destination is allowed with AppFlow
       //       it might require a change of approach in the future.
@@ -252,25 +245,22 @@ export abstract class FlowBase extends Resource implements IFlow {
     this.name = this.physicalName;
     this.source = props.source;
 
-    props.mappings.forEach((m) => this._addMapping(m));
+    props.mappings.forEach(m => this._addMapping(m));
 
     if (props.validations) {
-      props.validations.forEach((v) => this._addValidation(v));
+      props.validations.forEach(v => this._addValidation(v));
     }
 
     if (props.transforms) {
-      props.transforms.forEach((t) => this._addTransform(t));
+      props.transforms.forEach(t => this._addTransform(t));
     }
 
     if (props.filters) {
-      props.filters.forEach((f) => this._addFilter(f));
+      props.filters.forEach(f => this._addFilter(f));
     }
 
     this.node.addValidation({
-      validate: () =>
-        this.mappings.length === 0
-          ? ['A Flow must have at least one mapping']
-          : [],
+      validate: () => this.mappings.length === 0 ? ['A Flow must have at least one mapping'] : [],
     });
   }
 
@@ -305,11 +295,8 @@ export abstract class FlowBase extends Resource implements IFlow {
     return this.metric('FlowExecutionRecordsProcessed', options);
   }
 
-  private buildTriggerProperties(
-    scope: IConstruct,
-    id: string,
-    props: TriggerProperties,
-  ): CfnFlow.ScheduledTriggerPropertiesProperty {
+  private buildTriggerProperties(scope: IConstruct, id: string, props: TriggerProperties): CfnFlow.ScheduledTriggerPropertiesProperty {
+
     const updater = new FlowTimeUpdater(scope, `${id}Updater`, {
       schedule: props.schedule,
       startTime: props.properties?.startTime,
@@ -322,22 +309,17 @@ export abstract class FlowBase extends Resource implements IFlow {
       dataPullMode: props.dataPullConfig.mode,
       flowErrorDeactivationThreshold: props.flowErrorDeactivationThreshold,
       scheduleExpression: updater.scheduleExpression,
-      firstExecutionFrom:
-        props.properties?.firstExecutionFrom &&
+      firstExecutionFrom: props.properties?.firstExecutionFrom &&
         Math.floor(props.properties.firstExecutionFrom.getTime() / 1000),
       scheduleStartTime: props.properties?.startTime && updater.startTime,
       scheduleEndTime: props.properties?.endTime && updater.endTime,
-      scheduleOffset:
-        props.properties?.offset && props.properties.offset.toSeconds(),
+      scheduleOffset: props.properties?.offset && props.properties.offset.toSeconds(),
     };
   }
 
-  private initProjectionFilter(
-    sourceType: ConnectorType,
-  ): CfnFlow.TaskProperty {
+  private initProjectionFilter(sourceType: ConnectorType): CfnFlow.TaskProperty {
     const filterConnectorOperator: { [key: string]: string } = {};
-    filterConnectorOperator[sourceType.asTaskConnectorOperatorOrigin] =
-      'PROJECTION';
+    filterConnectorOperator[sourceType.asTaskConnectorOperatorOrigin] = 'PROJECTION';
 
     return {
       taskType: 'Filter',
@@ -347,10 +329,10 @@ export abstract class FlowBase extends Resource implements IFlow {
   }
 
   /**
-   * Set the catalog definitionfor the flow
-   *
-   * @internal
-   */
+     * Set the catalog definitionfor the flow
+     *
+     * @internal
+     */
   public _addCatalog(metadata: CfnFlow.MetadataCatalogConfigProperty) {
     this._catalogMetadata = metadata;
   }
@@ -410,9 +392,9 @@ export abstract class FlowBase extends Resource implements IFlow {
 
   private addProjectionField(boundMappingTasks: CfnFlow.TaskProperty[]) {
     // TODO: test if this satisfies all the requirements.
-    boundMappingTasks.forEach((boundMapping) => {
+    boundMappingTasks.forEach(boundMapping => {
       if (['Map', 'Filter'].includes(boundMapping.taskType)) {
-        boundMapping.sourceFields.forEach((field) => {
+        boundMapping.sourceFields.forEach(field => {
           if (!this._projectionFilter.sourceFields.includes(field)) {
             this._projectionFilter.sourceFields.push(field);
           }
@@ -448,16 +430,11 @@ export abstract class FlowBase extends Resource implements IFlow {
     return rule;
   }
 
-  private buildIncrementalPullConfig(
-    triggerConfig?: TriggerConfig,
-  ): CfnFlow.IncrementalPullConfigProperty | undefined {
-    return triggerConfig &&
-      triggerConfig.properties &&
-      triggerConfig.properties.dataPullConfig &&
-      triggerConfig.properties.dataPullConfig.timestampField
+  private buildIncrementalPullConfig(triggerConfig?: TriggerConfig): CfnFlow.IncrementalPullConfigProperty | undefined {
+    return triggerConfig && triggerConfig.properties && triggerConfig.properties.dataPullConfig
+      && triggerConfig.properties.dataPullConfig.timestampField
       ? {
-        datetimeTypeFieldName:
-            triggerConfig.properties.dataPullConfig.timestampField,
+        datetimeTypeFieldName: triggerConfig.properties.dataPullConfig.timestampField,
       }
       : undefined;
   }

--- a/test/core/flows/on-demand-flow-metrics.test.ts
+++ b/test/core/flows/on-demand-flow-metrics.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../src';
 
 describe('OnDemandFlow metrics', () => {
-  test('', () => {
+  test('default', () => {
 
     const stack = new Stack(undefined, 'TestStack');
 

--- a/test/core/flows/on-demand-flow.test.ts
+++ b/test/core/flows/on-demand-flow.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../src';
 
 describe('OnDemandFlow', () => {
-  test('', () => {
+  test('default', () => {
 
     const stack = new Stack(undefined, 'TestStack');
 
@@ -53,7 +53,7 @@ describe('OnDemandFlow', () => {
           },
         },
       ],
-      FlowName: 'OnDemandFlow',
+      FlowName: 'TestStackOnDemandFlow53F97EB9',
       SourceFlowConfig: {
         ConnectorType: 'S3',
         SourceConnectorProperties: {

--- a/test/core/flows/on-event-flow.test.ts
+++ b/test/core/flows/on-event-flow.test.ts
@@ -71,7 +71,7 @@ describe('OnEventFlow', () => {
             },
           },
         ],
-        FlowName: 'OnEventFlow',
+        FlowName: 'TestStackOnEventFlow4BA4B0C6',
         FlowStatus: 'Active',
         SourceFlowConfig: {
           ConnectorProfileName: 'appflow-tester',
@@ -203,7 +203,7 @@ describe('OnEventFlow', () => {
             },
           },
         ],
-        FlowName: 'OnEventFlow',
+        FlowName: 'TestStackOnEventFlow4BA4B0C6',
         SourceFlowConfig: {
           ConnectorProfileName: 'appflow-tester',
           ConnectorType: 'Salesforce',

--- a/test/core/flows/on-schedule-flow.test.ts
+++ b/test/core/flows/on-schedule-flow.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../src';
 
 describe('OnScheduleFlow', () => {
-  test('', () => {
+  test('default', () => {
     const stack = new Stack(undefined, 'TestStack');
 
     const bucket = new Bucket(stack, 'TestBucket');
@@ -58,7 +58,7 @@ describe('OnScheduleFlow', () => {
           },
         },
       ],
-      FlowName: 'OnScheduleFlow',
+      FlowName: 'TestStackOnScheduleFlow1BB655FE',
       SourceFlowConfig: {
         ConnectorType: 'S3',
         SourceConnectorProperties: {
@@ -131,7 +131,7 @@ describe('OnScheduleFlow', () => {
     const template = Template.fromStack(stack);
 
     template.hasResourceProperties('AWS::AppFlow::Flow', {
-      FlowName: 'OnScheduleFlow',
+      FlowName: 'TestStackOnScheduleFlow1BB655FE',
       TriggerConfig: {
         TriggerType: 'Scheduled',
         TriggerProperties: {

--- a/test/googleads/source.test.ts
+++ b/test/googleads/source.test.ts
@@ -68,7 +68,7 @@ describe('GoogleAdsSource', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ApiVersion: 'v16',
         ConnectorProfileName: 'dummy-profile',
@@ -180,7 +180,7 @@ describe('GoogleAdsSource', () => {
             },
           },
         ],
-        FlowName: 'TestFlow',
+        FlowName: 'TestStackTestFlow32CDAF42',
         SourceFlowConfig: {
           ApiVersion: 'v16',
           ConnectorProfileName: 'TestProfile',

--- a/test/googlebigquery/source.test.ts
+++ b/test/googlebigquery/source.test.ts
@@ -72,7 +72,7 @@ describe('GoogleBigQuerySource', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ApiVersion: 'v2',
         ConnectorProfileName: 'dummy-profile',
@@ -184,7 +184,7 @@ describe('GoogleBigQuerySource', () => {
             },
           },
         ],
-        FlowName: 'TestFlow',
+        FlowName: 'TestStackTestFlow32CDAF42',
         SourceFlowConfig: {
           ApiVersion: 'v2',
           ConnectorProfileName: 'TestProfile',

--- a/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "99b90d8d72bc84463ed65323f4e755875ece33ca0ffa2826f29e21ca8ecbca4b": {
+    "3b6b794667e363c9dd6a3fb162f4933fdaae19bdf8e484778b11e342d9e7cd2a": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "99b90d8d72bc84463ed65323f4e755875ece33ca0ffa2826f29e21ca8ecbca4b.json",
+          "objectKey": "3b6b794667e363c9dd6a3fb162f4933fdaae19bdf8e484778b11e342d9e7cd2a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.template.json
@@ -254,7 +254,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "1.0",
      "ConnectorProfileName": "TestConnectorProfile",

--- a/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "2ea312c67e9de1ffc6cc7a7242d9c0dc8a2f13f03308d829b5334435120fa7f0": {
+    "001d1c556f3980c516f91714a7bd71e01f87a79d1eb71439fe70619be725acb8": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2ea312c67e9de1ffc6cc7a7242d9c0dc8a2f13f03308d829b5334435120fa7f0.json",
+          "objectKey": "001d1c556f3980c516f91714a7bd71e01f87a79d1eb71439fe70619be725acb8.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.template.json
@@ -295,7 +295,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "v1beta",
      "ConnectorProfileName": "TestConnector",

--- a/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "36.3.0",
   "files": {
-    "6861d545ce03a23ba70eed7607eb9d7591a85a706ff66d03d5aad22687d28078": {
+    "feb047041840df9a2e4ae9e6f32343cdf78d2973fd7cd5cac8eb3e96b2f35126": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "6861d545ce03a23ba70eed7607eb9d7591a85a706ff66d03d5aad22687d28078.json",
+          "objectKey": "feb047041840df9a2e4ae9e6f32343cdf78d2973fd7cd5cac8eb3e96b2f35126.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.template.json
@@ -320,7 +320,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "V1",
      "ConnectorProfileName": "JdbcSmallTestConnectorProfile",

--- a/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/manifest.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/6861d545ce03a23ba70eed7607eb9d7591a85a706ff66d03d5aad22687d28078.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/feb047041840df9a2e4ae9e6f32343cdf78d2973fd7cd5cac8eb3e96b2f35126.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "532819537ceb30d89ceb283dc40f262ad262d89482a0756490279fea67d480e2": {
+    "8a7db1c69546c959e3b9002c2d22ef29554ff680c4522c612bcf7797123fb506": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "532819537ceb30d89ceb283dc40f262ad262d89482a0756490279fea67d480e2.json",
+          "objectKey": "8a7db1c69546c959e3b9002c2d22ef29554ff680c4522c612bcf7797123fb506.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.template.json
@@ -354,7 +354,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "V1",
      "ConnectorProfileName": "TestConnectorProfile",

--- a/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/manifest.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/532819537ceb30d89ceb283dc40f262ad262d89482a0756490279fea67d480e2.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/8a7db1c69546c959e3b9002c2d22ef29554ff680c4522c612bcf7797123fb506.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "d221bc6829242f33fb824716a6a9e09db02f0c425682ea8ff164aaf6eeabe707": {
+    "455f141c1e1aea44d999861bc52928465467e06520d4314331358441968cf01f": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d221bc6829242f33fb824716a6a9e09db02f0c425682ea8ff164aaf6eeabe707.json",
+          "objectKey": "455f141c1e1aea44d999861bc52928465467e06520d4314331358441968cf01f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.template.json
@@ -275,7 +275,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "3.0",
      "ConnectorProfileName": "TestConnectorProfile",

--- a/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.assets.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "71a287a54e5f2c6d27d3c67dbaa6a5a45bdb20ff32f2cb3f63bed9b1bb964956": {
+    "f4e64e738430d59f23243a6e72f8f2b5e544cd0cd195f0ff209af03236bfada4": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -23,7 +23,7 @@
       "destinations": {
         "current_account-us-east-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1",
-          "objectKey": "71a287a54e5f2c6d27d3c67dbaa6a5a45bdb20ff32f2cb3f63bed9b1bb964956.json",
+          "objectKey": "f4e64e738430d59f23243a6e72f8f2b5e544cd0cd195f0ff209af03236bfada4.json",
           "region": "us-east-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-east-1"
         }

--- a/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.template.json
@@ -314,7 +314,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "v9.2",
      "ConnectorProfileName": "TestConnector",

--- a/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/manifest.json
+++ b/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-us-east-1",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-us-east-1",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/71a287a54e5f2c6d27d3c67dbaa6a5a45bdb20ff32f2cb3f63bed9b1bb964956.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/f4e64e738430d59f23243a6e72f8f2b5e544cd0cd195f0ff209af03236bfada4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [

--- a/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "8eede5efa341871e439a6c48121a592749d86283fce3c03cab0b12d3c4580a9f": {
+    "ab4cd98a95f1b6112b78755dffeb8829a58eae4f39e17680c6c19dc56873c69a": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8eede5efa341871e439a6c48121a592749d86283fce3c03cab0b12d3c4580a9f.json",
+          "objectKey": "ab4cd98a95f1b6112b78755dffeb8829a58eae4f39e17680c6c19dc56873c69a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.template.json
@@ -299,7 +299,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "v1.0",
      "ConnectorProfileName": "TestConnector",

--- a/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "a22659df99cd0c562377a5afa6737f29d21021cabbad01dce9dd1fc3b1df4a62": {
+    "69344cdc441a5e8630ce224e32856c51537bb5e09d5f9356f09633b8ee89b71c": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a22659df99cd0c562377a5afa6737f29d21021cabbad01dce9dd1fc3b1df4a62.json",
+          "objectKey": "69344cdc441a5e8630ce224e32856c51537bb5e09d5f9356f09633b8ee89b71c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.template.json
@@ -675,7 +675,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ConnectorType": "S3",
      "SourceConnectorProperties": {

--- a/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "3ead0829d4c69f964790b8e2d7938836ce7b26fc71d156d6667786be92281a6c": {
+    "c8b2a0ca9315ea66e9199d26ae3f58bf1d37465643063f7d03378e8e80a460be": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3ead0829d4c69f964790b8e2d7938836ce7b26fc71d156d6667786be92281a6c.json",
+          "objectKey": "c8b2a0ca9315ea66e9199d26ae3f58bf1d37465643063f7d03378e8e80a460be.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.template.json
@@ -1450,7 +1450,7 @@
       }
      }
     ],
-    "FlowName": "SfdcToRedshiftELT",
+    "FlowName": "TestStackSfdcToRedshiftELT6AA1139C",
     "SourceFlowConfig": {
      "ConnectorProfileName": "TestProfile",
      "ConnectorType": "Salesforce",

--- a/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "7b44775df1172ce015e29ddc2f739b0981807203d058a7db35aa0f2c68d41468": {
+    "2746df22a565cc7664bcf732382a78e2861c3a31b1554ccdbfe1639c86da3318": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7b44775df1172ce015e29ddc2f739b0981807203d058a7db35aa0f2c68d41468.json",
+          "objectKey": "2746df22a565cc7664bcf732382a78e2861c3a31b1554ccdbfe1639c86da3318.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.template.json
@@ -308,7 +308,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "MetadataCatalogConfig": {
      "GlueDataCatalog": {
       "DatabaseName": {

--- a/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "451c09a79a7447bfd2abfb39793cae3d7fa286610e4ebadfc8d0ab3f30f9cecf": {
+    "25dd49245514a9bf4353a78a5dbf3250a11e169ba6bd32f23e8fb7b675dc559a": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "451c09a79a7447bfd2abfb39793cae3d7fa286610e4ebadfc8d0ab3f30f9cecf.json",
+          "objectKey": "25dd49245514a9bf4353a78a5dbf3250a11e169ba6bd32f23e8fb7b675dc559a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.template.json
@@ -368,7 +368,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ConnectorProfileName": "TestConnectorProfile",
      "ConnectorType": "SAPOData",

--- a/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "b102a1c737a4f30648645a4b0d8713c824fdb507298da5e4ad3ee7b3e9681320": {
+    "053fe7440138556715441f38b1ea21b8a1fd074d0f42f09362e1a9dcea2fbe40": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b102a1c737a4f30648645a4b0d8713c824fdb507298da5e4ad3ee7b3e9681320.json",
+          "objectKey": "053fe7440138556715441f38b1ea21b8a1fd074d0f42f09362e1a9dcea2fbe40.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.template.json
@@ -268,7 +268,7 @@
       }
      }
     ],
-    "FlowName": "OnDemandFlow",
+    "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ConnectorProfileName": "TestConnectorProfile",
      "ConnectorType": "Slack",

--- a/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "90975efa167a1d190e887698a5721b8dc65836c21f81f5831d728c668fba2f03": {
+    "e54e426b7a71f5771f41c2f2d5eab0bb8f810bbc64491875269f51cdea5a3d44": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "90975efa167a1d190e887698a5721b8dc65836c21f81f5831d728c668fba2f03.json",
+          "objectKey": "e54e426b7a71f5771f41c2f2d5eab0bb8f810bbc64491875269f51cdea5a3d44.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.template.json
+++ b/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.template.json
@@ -302,7 +302,7 @@
       }
      }
     ],
-    "FlowName": "EventFlow",
+    "FlowName": "TestStackEventFlow3DEF2313",
     "SourceFlowConfig": {
      "ConnectorProfileName": "TestConnectorProfile",
      "ConnectorType": "Salesforce",

--- a/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "8604fc446c33acde9d2377cc502cb0035df49f3df3f4ea823a622e80f8e2f9ca": {
+    "ebd6fc4cce953d7795f95b638d70af66539864f33bbc9aff2b944150699528ad": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8604fc446c33acde9d2377cc502cb0035df49f3df3f4ea823a622e80f8e2f9ca.json",
+          "objectKey": "ebd6fc4cce953d7795f95b638d70af66539864f33bbc9aff2b944150699528ad.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.template.json
+++ b/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.template.json
@@ -488,7 +488,7 @@
       }
      }
     ],
-    "FlowName": "OnScheduleFlow",
+    "FlowName": "TestStackOnScheduleFlow1BB655FE",
     "FlowStatus": "Active",
     "SourceFlowConfig": {
      "ConnectorType": "S3",

--- a/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.assets.json
@@ -43,7 +43,7 @@
         }
       }
     },
-    "1d369fa65e905db0f214acd0822cbe1a96e90dc33c8319d1d86e1f80aee5eda7": {
+    "fc4e6e3859fcdf797a04d136a8dea8fa73fd3a3e0871e51c73f6f83dff5df248": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -51,7 +51,7 @@
       "destinations": {
         "current_account-eu-west-2": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2",
-          "objectKey": "1d369fa65e905db0f214acd0822cbe1a96e90dc33c8319d1d86e1f80aee5eda7.json",
+          "objectKey": "fc4e6e3859fcdf797a04d136a8dea8fa73fd3a3e0871e51c73f6f83dff5df248.json",
           "region": "eu-west-2",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-eu-west-2"
         }

--- a/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.template.json
@@ -291,7 +291,7 @@
       }
      }
     ],
-    "FlowName": "OnScheduleFlow",
+    "FlowName": "TestStackOnScheduleFlow1BB655FE",
     "SourceFlowConfig": {
      "ApiVersion": "v1",
      "ConnectorProfileName": "TestConnector",

--- a/test/microsoftsharepointonline/source.test.ts
+++ b/test/microsoftsharepointonline/source.test.ts
@@ -70,7 +70,7 @@ describe('MicrosoftSharepointOnlineSource', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ApiVersion: 'v1.0',
         ConnectorProfileName: 'dummy-profile',
@@ -187,7 +187,7 @@ describe('MicrosoftSharepointOnlineSource', () => {
             },
           },
         ],
-        FlowName: 'TestFlow',
+        FlowName: 'TestStackTestFlow32CDAF42',
         SourceFlowConfig: {
           ApiVersion: 'v1.0',
           ConnectorProfileName: 'TestProfile',

--- a/test/salesforce/destination.test.ts
+++ b/test/salesforce/destination.test.ts
@@ -75,7 +75,7 @@ describe('SalesforceDestination', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ConnectorType: 'S3',
         SourceConnectorProperties: {
@@ -205,7 +205,7 @@ describe('SalesforceDestination', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ConnectorType: 'S3',
         SourceConnectorProperties: {

--- a/test/salesforce/source.test.ts
+++ b/test/salesforce/source.test.ts
@@ -71,7 +71,7 @@ describe('SalesforceSource', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ApiVersion: '1',
         ConnectorProfileName: 'dummy-profile',
@@ -195,7 +195,7 @@ describe('SalesforceSource', () => {
           },
         },
       ],
-      FlowName: 'TestFlow',
+      FlowName: 'TestStackTestFlow32CDAF42',
       SourceFlowConfig: {
         ApiVersion: '1',
         ConnectorProfileName: 'TestProfile',


### PR DESCRIPTION
Fixes #360 

Implements a default naming strategy for `Flow` resources. Now, when no `name` property is passed to a construct the name is autogenerated with a hash suffix. Additionally, automated naming adheres to the [FlowName CFN specification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-flow.html#cfn-appflow-flow-flowname).