### PR TITLE
fix!: applying consistent naming convention for L1 and L2 constructs

### DIFF
--- a/src/core/flows/flow-base.ts
+++ b/src/core/flows/flow-base.ts
@@ -203,7 +203,7 @@ export abstract class FlowBase extends Resource implements IFlow {
       props.source.connectorType,
     );
 
-    const resource = new CfnFlow(this, id, {
+    const resource = new CfnFlow(this, "Resource", {
       flowName: this.physicalName,
       flowStatus: props.status,
       triggerConfig: {

--- a/test/asana/profile.test.ts
+++ b/test/asana/profile.test.ts
@@ -21,7 +21,7 @@ describe("AsanaConnectorProfileProps", () => {
       {
         ConnectionMode: "Public",
         ConnectorLabel: "Asana",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {

--- a/test/core/flows/on-event-flow.test.ts
+++ b/test/core/flows/on-event-flow.test.ts
@@ -138,7 +138,7 @@ describe("OnEventFlow", () => {
           source: ["aws.appflow"],
           resources: [
             {
-              "Fn::GetAtt": ["OnEventFlowBAB74E7A", "FlowArn"],
+              "Fn::GetAtt": ["OnEventFlowF92CD86B", "FlowArn"],
             },
           ],
           "detail-type": ["AppFlow Event Flow Report"],
@@ -151,7 +151,7 @@ describe("OnEventFlow", () => {
           source: ["aws.appflow"],
           resources: [
             {
-              "Fn::GetAtt": ["OnEventFlowBAB74E7A", "FlowArn"],
+              "Fn::GetAtt": ["OnEventFlowF92CD86B", "FlowArn"],
             },
           ],
           "detail-type": ["AppFlow Event Flow Deactivated"],

--- a/test/googleads/profile.test.ts
+++ b/test/googleads/profile.test.ts
@@ -38,7 +38,7 @@ describe("GoogleAdsConnectorProfile", () => {
       {
         ConnectionMode: "Public",
         ConnectorLabel: "GoogleAds",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {

--- a/test/googleads/source.test.ts
+++ b/test/googleads/source.test.ts
@@ -153,7 +153,7 @@ describe("GoogleAdsSource", () => {
 
     template.hasResourceProperties("AWS::AppFlow::ConnectorProfile", {
       ConnectionMode: "Public",
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "CustomConnector",
       ConnectorLabel: "GoogleAds",
       ConnectorProfileConfig: {
@@ -196,7 +196,7 @@ describe("GoogleAdsSource", () => {
         FlowName: "TestStackTestFlow32CDAF42",
         SourceFlowConfig: {
           ApiVersion: "v16",
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "CustomConnector",
           SourceConnectorProperties: {
             CustomConnector: {
@@ -226,7 +226,7 @@ describe("GoogleAdsSource", () => {
       DependsOn: [
         "TestBucketPolicyBA12ED38",
         "TestBucket560B80BC",
-        "TestProfile45C36389",
+        "TestProfileBC0F4812",
       ],
     });
   });

--- a/test/googlebigquery/profile.test.ts
+++ b/test/googlebigquery/profile.test.ts
@@ -32,7 +32,7 @@ describe("GoogleBigQueryConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorLabel: "GoogleBigQuery",
         ConnectorProfileConfig: {
@@ -87,7 +87,7 @@ describe("GoogleBigQueryConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorLabel: "GoogleBigQuery",
         ConnectorProfileConfig: {
@@ -199,7 +199,7 @@ describe("GoogleBigQueryConnectorProfile", () => {
     Template.fromStack(stack).hasResource("AWS::AppFlow::ConnectorProfile", {
       Properties: {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorLabel: "GoogleBigQuery",
         ConnectorProfileConfig: {

--- a/test/googlebigquery/source.test.ts
+++ b/test/googlebigquery/source.test.ts
@@ -159,7 +159,7 @@ describe("GoogleBigQuerySource", () => {
 
     template.hasResourceProperties("AWS::AppFlow::ConnectorProfile", {
       ConnectionMode: "Public",
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "CustomConnector",
       ConnectorLabel: "GoogleBigQuery",
       ConnectorProfileConfig: {
@@ -202,7 +202,7 @@ describe("GoogleBigQuerySource", () => {
         FlowName: "TestStackTestFlow32CDAF42",
         SourceFlowConfig: {
           ApiVersion: "v2",
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "CustomConnector",
           SourceConnectorProperties: {
             CustomConnector: {
@@ -232,7 +232,7 @@ describe("GoogleBigQuerySource", () => {
       DependsOn: [
         "TestBucketPolicyBA12ED38",
         "TestBucket560B80BC",
-        "TestProfile45C36389",
+        "TestProfileBC0F4812",
       ],
     });
   });

--- a/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "3b6b794667e363c9dd6a3fb162f4933fdaae19bdf8e484778b11e342d9e7cd2a": {
+    "9cce408075f59c2146a2f2f55df048ba6820342a0969c337383c6b308faac634": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3b6b794667e363c9dd6a3fb162f4933fdaae19bdf8e484778b11e342d9e7cd2a.json",
+          "objectKey": "9cce408075f59c2146a2f2f55df048ba6820342a0969c337383c6b308faac634.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-asana-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -42,7 +42,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -239,7 +239,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -257,7 +257,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "1.0",
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -307,7 +307,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   }
  },

--- a/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "001d1c556f3980c516f91714a7bd71e01f87a79d1eb71439fe70619be725acb8": {
+    "3e766f62241e624040d7f72adc0d4e7438e19f3e765ee790b1db990354eaf76c": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "001d1c556f3980c516f91714a7bd71e01f87a79d1eb71439fe70619be725acb8.json",
+          "objectKey": "3e766f62241e624040d7f72adc0d4e7438e19f3e765ee790b1db990354eaf76c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-googleanalytics4-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorEE9F0A13": {
+  "TestConnectorF96C459B": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -83,7 +83,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnector",
+    "ConnectorProfileName": "TestStackTestConnector553270CD",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -280,7 +280,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -298,7 +298,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "v1beta",
-     "ConnectorProfileName": "TestConnector",
+     "ConnectorProfileName": "TestStackTestConnector553270CD",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -406,7 +406,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorEE9F0A13"
+    "TestConnectorF96C459B"
    ]
   }
  },

--- a/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.assets.json
@@ -1,7 +1,7 @@
 {
   "version": "36.3.0",
   "files": {
-    "feb047041840df9a2e4ae9e6f32343cdf78d2973fd7cd5cac8eb3e96b2f35126": {
+    "9dd52abf0489ce71ca2300e218bd47d2fc5454dfecdf034daf6229b6823feec4": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -9,7 +9,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "feb047041840df9a2e4ae9e6f32343cdf78d2973fd7cd5cac8eb3e96b2f35126.json",
+          "objectKey": "9dd52abf0489ce71ca2300e218bd47d2fc5454dfecdf034daf6229b6823feec4.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "JdbcSmallTestConnectorProfileD137BC4A": {
+  "JdbcSmallTestConnectorProfile4B32988D": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -142,11 +142,11 @@
       }
      }
     },
-    "ConnectorProfileName": "JdbcSmallTestConnectorProfile",
+    "ConnectorProfileName": "TestStackJdbcSmallTestConnectorProfileCEFC6AC7",
     "ConnectorType": "CustomConnector"
    }
   },
-  "AmazonRdsTestConnectorProfileDA7BF797": {
+  "AmazonRdsTestConnectorProfile5A37DC65": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -269,17 +269,17 @@
       }
      }
     },
-    "ConnectorProfileName": "AmazonRdsTestConnectorProfile",
+    "ConnectorProfileName": "TestStackAmazonRdsTestConnectorProfileAD9F9A54",
     "ConnectorType": "CustomConnector"
    }
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
      {
       "ApiVersion": "1.0",
-      "ConnectorProfileName": "AmazonRdsTestConnectorProfile",
+      "ConnectorProfileName": "TestStackAmazonRdsTestConnectorProfileAD9F9A54",
       "ConnectorType": "CustomConnector",
       "DestinationConnectorProperties": {
        "CustomConnector": {
@@ -323,7 +323,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "V1",
-     "ConnectorProfileName": "JdbcSmallTestConnectorProfile",
+     "ConnectorProfileName": "TestStackJdbcSmallTestConnectorProfileCEFC6AC7",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -425,8 +425,8 @@
     }
    },
    "DependsOn": [
-    "AmazonRdsTestConnectorProfileDA7BF797",
-    "JdbcSmallTestConnectorProfileD137BC4A"
+    "AmazonRdsTestConnectorProfile5A37DC65",
+    "JdbcSmallTestConnectorProfile4B32988D"
    ]
   }
  },

--- a/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/manifest.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-amazonrdsforpostgresql.integ.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/feb047041840df9a2e4ae9e6f32343cdf78d2973fd7cd5cac8eb3e96b2f35126.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/9dd52abf0489ce71ca2300e218bd47d2fc5454dfecdf034daf6229b6823feec4.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -34,22 +34,22 @@
         "TestStack.assets"
       ],
       "metadata": {
-        "/TestStack/JdbcSmallTestConnectorProfile/JdbcSmallTestConnectorProfile": [
+        "/TestStack/JdbcSmallTestConnectorProfile/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "JdbcSmallTestConnectorProfileD137BC4A"
+            "data": "JdbcSmallTestConnectorProfile4B32988D"
           }
         ],
-        "/TestStack/AmazonRdsTestConnectorProfile/AmazonRdsTestConnectorProfile": [
+        "/TestStack/AmazonRdsTestConnectorProfile/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AmazonRdsTestConnectorProfileDA7BF797"
+            "data": "AmazonRdsTestConnectorProfile5A37DC65"
           }
         ],
-        "/TestStack/OnDemandFlow/OnDemandFlow": [
+        "/TestStack/OnDemandFlow/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "OnDemandFlow4ECA54C5"
+            "data": "OnDemandFlow00CE33FE"
           }
         ],
         "/TestStack/BootstrapVersion": [

--- a/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "8a7db1c69546c959e3b9002c2d22ef29554ff680c4522c612bcf7797123fb506": {
+    "dab88463c1b1f3094d4aedc3d0cb2b6273c5c591e337af887488109233d93fc6": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8a7db1c69546c959e3b9002c2d22ef29554ff680c4522c612bcf7797123fb506.json",
+          "objectKey": "dab88463c1b1f3094d4aedc3d0cb2b6273c5c591e337af887488109233d93fc6.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -142,7 +142,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -339,7 +339,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -357,7 +357,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "V1",
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -419,7 +419,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   }
  },

--- a/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/manifest.json
+++ b/test/integ/ondemand-jdbcsmalldatascale-to-s3.integ.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/8a7db1c69546c959e3b9002c2d22ef29554ff680c4522c612bcf7797123fb506.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/dab88463c1b1f3094d4aedc3d0cb2b6273c5c591e337af887488109233d93fc6.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -34,10 +34,10 @@
         "TestStack.assets"
       ],
       "metadata": {
-        "/TestStack/TestConnectorProfile/TestConnectorProfile": [
+        "/TestStack/TestConnectorProfile/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "TestConnectorProfileD7470107"
+            "data": "TestConnectorProfile61825F3E"
           }
         ],
         "/TestStack/TestBucket/Resource": [
@@ -82,10 +82,10 @@
             "data": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F"
           }
         ],
-        "/TestStack/OnDemandFlow/OnDemandFlow": [
+        "/TestStack/OnDemandFlow/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "OnDemandFlow4ECA54C5"
+            "data": "OnDemandFlow00CE33FE"
           }
         ],
         "/TestStack/BootstrapVersion": [

--- a/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "455f141c1e1aea44d999861bc52928465467e06520d4314331358441968cf01f": {
+    "846ed686620de8f82969c360d5d3fc93b2daf7e3afbdbaf1dd25083b27201c21": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "455f141c1e1aea44d999861bc52928465467e06520d4314331358441968cf01f.json",
+          "objectKey": "846ed686620de8f82969c360d5d3fc93b2daf7e3afbdbaf1dd25083b27201c21.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-mailchimp-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -63,7 +63,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -260,7 +260,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -278,7 +278,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "3.0",
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -309,7 +309,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   }
  },

--- a/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.assets.json
@@ -15,7 +15,7 @@
         }
       }
     },
-    "f4e64e738430d59f23243a6e72f8f2b5e544cd0cd195f0ff209af03236bfada4": {
+    "a7e9e94497cbe41b814c241bcafefaabe68ece70b82575fac7a7e91ce1d79f8f": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -23,7 +23,7 @@
       "destinations": {
         "current_account-us-east-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1",
-          "objectKey": "f4e64e738430d59f23243a6e72f8f2b5e544cd0cd195f0ff209af03236bfada4.json",
+          "objectKey": "a7e9e94497cbe41b814c241bcafefaabe68ece70b82575fac7a7e91ce1d79f8f.json",
           "region": "us-east-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-east-1"
         }

--- a/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorEE9F0A13": {
+  "TestConnectorF96C459B": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -104,7 +104,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnector",
+    "ConnectorProfileName": "TestStackTestConnector553270CD",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -293,7 +293,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -317,7 +317,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "v9.2",
-     "ConnectorProfileName": "TestConnector",
+     "ConnectorProfileName": "TestStackTestConnector553270CD",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -364,7 +364,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorEE9F0A13"
+    "TestConnectorF96C459B"
    ]
   }
  },

--- a/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/manifest.json
+++ b/test/integ/ondemand-microsoftdynamics365-to-s3.integ.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-us-east-1",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-us-east-1",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/f4e64e738430d59f23243a6e72f8f2b5e544cd0cd195f0ff209af03236bfada4.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/a7e9e94497cbe41b814c241bcafefaabe68ece70b82575fac7a7e91ce1d79f8f.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [
@@ -34,10 +34,10 @@
         "TestStack.assets"
       ],
       "metadata": {
-        "/TestStack/TestConnector/TestConnector": [
+        "/TestStack/TestConnector/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "TestConnectorEE9F0A13"
+            "data": "TestConnectorF96C459B"
           }
         ],
         "/TestStack/TestBucket/Resource": [
@@ -76,10 +76,10 @@
             "data": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F"
           }
         ],
-        "/TestStack/OnDemandFlow/OnDemandFlow": [
+        "/TestStack/OnDemandFlow/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "OnDemandFlow4ECA54C5"
+            "data": "OnDemandFlow00CE33FE"
           }
         ],
         "/TestStack/BootstrapVersion": [

--- a/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "ab4cd98a95f1b6112b78755dffeb8829a58eae4f39e17680c6c19dc56873c69a": {
+    "cc43c8729c3e39d0846ffedfe2cff95ecc6b22082ac1ee885caabcb2b6144511": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ab4cd98a95f1b6112b78755dffeb8829a58eae4f39e17680c6c19dc56873c69a.json",
+          "objectKey": "cc43c8729c3e39d0846ffedfe2cff95ecc6b22082ac1ee885caabcb2b6144511.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-microsoftsharepointonline-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorEE9F0A13": {
+  "TestConnectorF96C459B": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -81,7 +81,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnector",
+    "ConnectorProfileName": "TestStackTestConnector553270CD",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -278,7 +278,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -302,7 +302,7 @@
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
      "ApiVersion": "v1.0",
-     "ConnectorProfileName": "TestConnector",
+     "ConnectorProfileName": "TestStackTestConnector553270CD",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -374,7 +374,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorEE9F0A13"
+    "TestConnectorF96C459B"
    ]
   }
  },

--- a/test/integ/ondemand-s3-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-s3-to-s3.integ.snapshot/TestStack.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "04bac35225200905aca61924fe664f2403663a62d823cdc3d4aec2dc54aaf0fe": {
+    "5b65a870c2080e9d2904b4fd05a074761b653121409e663685ddc4afd5646c13": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "04bac35225200905aca61924fe664f2403663a62d823cdc3d4aec2dc54aaf0fe.json",
+          "objectKey": "5b65a870c2080e9d2904b4fd05a074761b653121409e663685ddc4afd5646c13.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-s3-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-s3-to-s3.integ.snapshot/TestStack.template.json
@@ -520,7 +520,7 @@
     "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [

--- a/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "69344cdc441a5e8630ce224e32856c51537bb5e09d5f9356f09633b8ee89b71c": {
+    "fda0a8c9a4ebd1092e63744b8b697a17873658010ec830ed9c8139338146315c": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "69344cdc441a5e8630ce224e32856c51537bb5e09d5f9356f09633b8ee89b71c.json",
+          "objectKey": "fda0a8c9a4ebd1092e63744b8b697a17873658010ec830ed9c8139338146315c.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-s3-to-snowflake.integ.snapshot/TestStack.template.json
@@ -393,7 +393,7 @@
     "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265"
    ]
   },
-  "SnowTestConnectorF6AA1E5C": {
+  "SnowTestConnector2D8FD8BF": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -571,16 +571,16 @@
       }
      }
     },
-    "ConnectorProfileName": "SnowTestConnector",
+    "ConnectorProfileName": "TestStackSnowTestConnectorE378906D",
     "ConnectorType": "Snowflake"
    }
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
      {
-      "ConnectorProfileName": "SnowTestConnector",
+      "ConnectorProfileName": "TestStackSnowTestConnectorE378906D",
       "ConnectorType": "Snowflake",
       "DestinationConnectorProperties": {
        "Snowflake": {
@@ -710,7 +710,7 @@
     }
    },
    "DependsOn": [
-    "SnowTestConnectorF6AA1E5C",
+    "SnowTestConnector2D8FD8BF",
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",

--- a/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.assets.json
@@ -53,7 +53,7 @@
         }
       }
     },
-    "c8b2a0ca9315ea66e9199d26ae3f58bf1d37465643063f7d03378e8e80a460be": {
+    "1b9f56458744b950a8e3ff681003641aca4e55121c37338909ecdbd283ac38dc": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -61,7 +61,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c8b2a0ca9315ea66e9199d26ae3f58bf1d37465643063f7d03378e8e80a460be.json",
+          "objectKey": "1b9f56458744b950a8e3ff681003641aca4e55121c37338909ecdbd283ac38dc.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-salesforce-to-redshift.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestProfile45C36389": {
+  "TestProfileBC0F4812": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -56,7 +56,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestProfile",
+    "ConnectorProfileName": "TestStackTestProfile18724107",
     "ConnectorType": "Salesforce"
    }
   },
@@ -1000,7 +1000,7 @@
     "QueryRedshiftDatabase3de5bea727da479686625efb56431b5fServiceRole0A90D717"
    ]
   },
-  "TestRedshiftProfileC7C6727A": {
+  "TestRedshiftProfile0FD958FE": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -1035,7 +1035,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestRedshiftProfile",
+    "ConnectorProfileName": "TestStackTestRedshiftProfileF3740561",
     "ConnectorType": "Redshift"
    },
    "DependsOn": [
@@ -1422,12 +1422,12 @@
     ]
    }
   },
-  "SfdcToRedshiftELTFC79C6AA": {
+  "SfdcToRedshiftELT3CD9B9F4": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
      {
-      "ConnectorProfileName": "TestRedshiftProfile",
+      "ConnectorProfileName": "TestStackTestRedshiftProfileF3740561",
       "ConnectorType": "Redshift",
       "DestinationConnectorProperties": {
        "Redshift": {
@@ -1452,7 +1452,7 @@
     ],
     "FlowName": "TestStackSfdcToRedshiftELT6AA1139C",
     "SourceFlowConfig": {
-     "ConnectorProfileName": "TestProfile",
+     "ConnectorProfileName": "TestStackTestProfile18724107",
      "ConnectorType": "Salesforce",
      "SourceConnectorProperties": {
       "Salesforce": {
@@ -1496,8 +1496,8 @@
     }
    },
    "DependsOn": [
-    "TestProfile45C36389",
-    "TestRedshiftProfileC7C6727A",
+    "TestProfileBC0F4812",
+    "TestRedshiftProfile0FD958FE",
     "TestTableProviderframeworkonEventFD35FC3D",
     "TestTableProviderframeworkonEventServiceRoleDefaultPolicy96D55F94",
     "TestTableProviderframeworkonEventServiceRole585FCC2A",

--- a/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "2746df22a565cc7664bcf732382a78e2861c3a31b1554ccdbfe1639c86da3318": {
+    "c418d12e6fbb68223420b42438c36db02ce4d4544977681f61a65099de925c64": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2746df22a565cc7664bcf732382a78e2861c3a31b1554ccdbfe1639c86da3318.json",
+          "objectKey": "c418d12e6fbb68223420b42438c36db02ce4d4544977681f61a65099de925c64.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-salesforce-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -76,7 +76,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "Salesforce"
    }
   },
@@ -284,7 +284,7 @@
     }
    }
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -324,7 +324,7 @@
      }
     },
     "SourceFlowConfig": {
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "Salesforce",
      "SourceConnectorProperties": {
       "Salesforce": {
@@ -385,7 +385,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107",
+    "TestConnectorProfile61825F3E",
     "TestDatabase7A4A91C2"
    ]
   },

--- a/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "25dd49245514a9bf4353a78a5dbf3250a11e169ba6bd32f23e8fb7b675dc559a": {
+    "53ccd44c8cbb34eec81e922824e9a9b4fbd616f3ccebfdc09c4aa8e4c9928352": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "25dd49245514a9bf4353a78a5dbf3250a11e169ba6bd32f23e8fb7b675dc559a.json",
+          "objectKey": "53ccd44c8cbb34eec81e922824e9a9b4fbd616f3ccebfdc09c4aa8e4c9928352.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-sapodata-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -156,7 +156,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "SAPOData"
    }
   },
@@ -353,7 +353,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -370,7 +370,7 @@
     ],
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "SAPOData",
      "SourceConnectorProperties": {
       "SAPOData": {
@@ -420,7 +420,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   }
  },

--- a/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "053fe7440138556715441f38b1ea21b8a1fd074d0f42f09362e1a9dcea2fbe40": {
+    "3fe1a9372fff9899182efc45a80268f00af54210dddd1808083a2baf6567435a": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "053fe7440138556715441f38b1ea21b8a1fd074d0f42f09362e1a9dcea2fbe40.json",
+          "objectKey": "3fe1a9372fff9899182efc45a80268f00af54210dddd1808083a2baf6567435a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/ondemand-slack-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -56,7 +56,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "Slack"
    }
   },
@@ -253,7 +253,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnDemandFlow4ECA54C5": {
+  "OnDemandFlow00CE33FE": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -270,7 +270,7 @@
     ],
     "FlowName": "TestStackOnDemandFlow53F97EB9",
     "SourceFlowConfig": {
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "Slack",
      "SourceConnectorProperties": {
       "Slack": {
@@ -320,7 +320,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   }
  },

--- a/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.assets.json
@@ -14,7 +14,7 @@
         }
       }
     },
-    "e54e426b7a71f5771f41c2f2d5eab0bb8f810bbc64491875269f51cdea5a3d44": {
+    "643530a7be171aa093dddcbf0b25665ba3802345358e59c671cd87de42fe0b73": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e54e426b7a71f5771f41c2f2d5eab0bb8f810bbc64491875269f51cdea5a3d44.json",
+          "objectKey": "643530a7be171aa093dddcbf0b25665ba3802345358e59c671cd87de42fe0b73.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.template.json
+++ b/test/integ/onevent-salesforce-to-eventbridge.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -76,7 +76,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "Salesforce"
    }
   },
@@ -273,7 +273,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "EventFlowF93BCAAA": {
+  "EventFlow0B765D17": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -304,7 +304,7 @@
     ],
     "FlowName": "TestStackEventFlow3DEF2313",
     "SourceFlowConfig": {
-     "ConnectorProfileName": "TestConnectorProfile",
+     "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
      "ConnectorType": "Salesforce",
      "SourceConnectorProperties": {
       "Salesforce": {
@@ -335,7 +335,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   },
   "EventFlowcaptureOnRunStartedBC55C943": {
@@ -348,7 +348,7 @@
      "resources": [
       {
        "Fn::GetAtt": [
-        "EventFlowF93BCAAA",
+        "EventFlow0B765D17",
         "FlowArn"
        ]
       }
@@ -363,7 +363,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107"
+    "TestConnectorProfile61825F3E"
    ]
   }
  },

--- a/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "2a51eba8e5d99179baf1d3729daf334e9f32934d98f23eafa6afca3edc2a0152": {
+    "89a63f4028b9a330d79c7e195975b4f91d5ae0edc97dc57135c7db5366dfa72b": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "2a51eba8e5d99179baf1d3729daf334e9f32934d98f23eafa6afca3edc2a0152.json",
+          "objectKey": "89a63f4028b9a330d79c7e195975b4f91d5ae0edc97dc57135c7db5366dfa72b.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.template.json
+++ b/test/integ/onschedule-s3-to-salesforce.integ.snapshot/TestStack.template.json
@@ -393,7 +393,7 @@
     "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265"
    ]
   },
-  "TestConnectorProfileD7470107": {
+  "TestConnectorProfile61825F3E": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -469,16 +469,16 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnectorProfile",
+    "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
     "ConnectorType": "Salesforce"
    }
   },
-  "OnScheduleFlow9A474F3B": {
+  "OnScheduleFlow3BE8D5D0": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
      {
-      "ConnectorProfileName": "TestConnectorProfile",
+      "ConnectorProfileName": "TestStackTestConnectorProfileD7C70DA6",
       "ConnectorType": "Salesforce",
       "DestinationConnectorProperties": {
        "Salesforce": {
@@ -593,7 +593,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107",
+    "TestConnectorProfile61825F3E",
     "TestDeploymentAwsCliLayerACB69B63",
     "TestDeploymentCustomResource6C695E22"
    ]
@@ -608,7 +608,7 @@
      "resources": [
       {
        "Fn::GetAtt": [
-        "OnScheduleFlow9A474F3B",
+        "OnScheduleFlow3BE8D5D0",
         "FlowArn"
        ]
       }
@@ -624,7 +624,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107",
+    "TestConnectorProfile61825F3E",
     "TestDeploymentAwsCliLayerACB69B63",
     "TestDeploymentCustomResource6C695E22"
    ]
@@ -639,7 +639,7 @@
      "resources": [
       {
        "Fn::GetAtt": [
-        "OnScheduleFlow9A474F3B",
+        "OnScheduleFlow3BE8D5D0",
         "FlowArn"
        ]
       }
@@ -655,7 +655,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorProfileD7470107",
+    "TestConnectorProfile61825F3E",
     "TestDeploymentAwsCliLayerACB69B63",
     "TestDeploymentCustomResource6C695E22"
    ]

--- a/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.assets.json
+++ b/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.assets.json
@@ -43,7 +43,7 @@
         }
       }
     },
-    "21d180fd822bbbc94fc63309eb06971458d4c665770012193a63ccd475955953": {
+    "54d0ced6422ec1ebd6880d44fa6bd653b6189d2f59c8e373ae4f9e2571d7e0c6": {
       "source": {
         "path": "TestStack.template.json",
         "packaging": "file"
@@ -51,7 +51,7 @@
       "destinations": {
         "current_account-eu-west-2": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2",
-          "objectKey": "21d180fd822bbbc94fc63309eb06971458d4c665770012193a63ccd475955953.json",
+          "objectKey": "54d0ced6422ec1ebd6880d44fa6bd653b6189d2f59c8e373ae4f9e2571d7e0c6.json",
           "region": "eu-west-2",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-eu-west-2"
         }

--- a/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.template.json
+++ b/test/integ/onschedule-salesforce-marketing-cloud-to-s3.integ.snapshot/TestStack.template.json
@@ -1,6 +1,6 @@
 {
  "Resources": {
-  "TestConnectorEE9F0A13": {
+  "TestConnectorF96C459B": {
    "Type": "AWS::AppFlow::ConnectorProfile",
    "Properties": {
     "ConnectionMode": "Public",
@@ -87,7 +87,7 @@
       }
      }
     },
-    "ConnectorProfileName": "TestConnector",
+    "ConnectorProfileName": "TestStackTestConnector553270CD",
     "ConnectorType": "CustomConnector"
    }
   },
@@ -276,7 +276,7 @@
     "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
    ]
   },
-  "OnScheduleFlow9A474F3B": {
+  "OnScheduleFlow3BE8D5D0": {
    "Type": "AWS::AppFlow::Flow",
    "Properties": {
     "DestinationFlowConfigList": [
@@ -294,7 +294,7 @@
     "FlowName": "TestStackOnScheduleFlow1BB655FE",
     "SourceFlowConfig": {
      "ApiVersion": "v1",
-     "ConnectorProfileName": "TestConnector",
+     "ConnectorProfileName": "TestStackTestConnector553270CD",
      "ConnectorType": "CustomConnector",
      "SourceConnectorProperties": {
       "CustomConnector": {
@@ -391,7 +391,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorEE9F0A13"
+    "TestConnectorF96C459B"
    ]
   },
   "OnScheduleFlowOnRunStarted5B6B0F14": {
@@ -404,7 +404,7 @@
      "resources": [
       {
        "Fn::GetAtt": [
-        "OnScheduleFlow9A474F3B",
+        "OnScheduleFlow3BE8D5D0",
         "FlowArn"
        ]
       }
@@ -420,7 +420,7 @@
     "TestBucketAutoDeleteObjectsCustomResource8FEAABD5",
     "TestBucketPolicyBA12ED38",
     "TestBucket560B80BC",
-    "TestConnectorEE9F0A13"
+    "TestConnectorF96C459B"
    ]
   },
   "OnScheduleFlowUpdater39178314": {

--- a/test/mailchimp/profile.test.ts
+++ b/test/mailchimp/profile.test.ts
@@ -22,7 +22,7 @@ describe("MailchimpConnectorProfileProps", () => {
       {
         ConnectionMode: "Public",
         ConnectorLabel: "Mailchimp",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {

--- a/test/marketo/profile.test.ts
+++ b/test/marketo/profile.test.ts
@@ -32,7 +32,7 @@ describe("MarketoConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Marketo",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -76,7 +76,7 @@ describe("MarketoConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Marketo",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -166,7 +166,7 @@ describe("MarketoConnectorProfile", () => {
     Template.fromStack(stack).hasResource("AWS::AppFlow::ConnectorProfile", {
       Properties: {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Marketo",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {

--- a/test/marketo/source.test.ts
+++ b/test/marketo/source.test.ts
@@ -112,7 +112,7 @@ describe("MarketoSource", () => {
 
     template.hasResourceProperties("AWS::AppFlow::ConnectorProfile", {
       ConnectionMode: "Public",
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "Marketo",
       ConnectorProfileConfig: {
         ConnectorProfileCredentials: {
@@ -133,7 +133,7 @@ describe("MarketoSource", () => {
     template.hasResource("AWS::AppFlow::Flow", {
       Properties: {
         SourceFlowConfig: {
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "Marketo",
           SourceConnectorProperties: {
             Marketo: {
@@ -145,7 +145,7 @@ describe("MarketoSource", () => {
       DependsOn: [
         "TestBucketPolicyBA12ED38",
         "TestBucket560B80BC",
-        "TestProfile45C36389",
+        "TestProfileBC0F4812",
       ],
     });
   });

--- a/test/microsoftsharepointonline/profile.test.ts
+++ b/test/microsoftsharepointonline/profile.test.ts
@@ -35,7 +35,7 @@ describe("MicrosoftSharepointOnlineConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorLabel: "MicrosoftSharePointOnline",
         ConnectorProfileConfig: {
@@ -91,7 +91,7 @@ describe("MicrosoftSharepointOnlineConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorLabel: "MicrosoftSharePointOnline",
         ConnectorProfileConfig: {
@@ -203,7 +203,7 @@ describe("MicrosoftSharepointOnlineConnectorProfile", () => {
     Template.fromStack(stack).hasResource("AWS::AppFlow::ConnectorProfile", {
       Properties: {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "CustomConnector",
         ConnectorLabel: "MicrosoftSharePointOnline",
         ConnectorProfileConfig: {

--- a/test/microsoftsharepointonline/source.test.ts
+++ b/test/microsoftsharepointonline/source.test.ts
@@ -177,7 +177,7 @@ describe("MicrosoftSharepointOnlineSource", () => {
 
     template.hasResourceProperties("AWS::AppFlow::ConnectorProfile", {
       ConnectionMode: "Public",
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "CustomConnector",
       ConnectorLabel: "MicrosoftSharePointOnline",
       ConnectorProfileConfig: {
@@ -221,7 +221,7 @@ describe("MicrosoftSharepointOnlineSource", () => {
         FlowName: "TestStackTestFlow32CDAF42",
         SourceFlowConfig: {
           ApiVersion: "v1.0",
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "CustomConnector",
           SourceConnectorProperties: {
             CustomConnector: {
@@ -256,7 +256,7 @@ describe("MicrosoftSharepointOnlineSource", () => {
       DependsOn: [
         "TestBucketPolicyBA12ED38",
         "TestBucket560B80BC",
-        "TestProfile45C36389",
+        "TestProfileBC0F4812",
       ],
     });
   });

--- a/test/salesforce/destination.test.ts
+++ b/test/salesforce/destination.test.ts
@@ -205,14 +205,14 @@ describe("SalesforceDestination", () => {
           },
         },
       },
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "Salesforce",
     });
 
     template.hasResourceProperties("AWS::AppFlow::Flow", {
       DestinationFlowConfigList: [
         {
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "Salesforce",
           DestinationConnectorProperties: {
             Salesforce: {

--- a/test/salesforce/profile.test.ts
+++ b/test/salesforce/profile.test.ts
@@ -33,7 +33,7 @@ describe("SalesforceConnectorProfileProps", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Salesforce",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -127,7 +127,7 @@ describe("SalesforceConnectorProfileProps", () => {
             },
           },
         },
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Salesforce",
       },
     );
@@ -209,7 +209,7 @@ describe("SalesforceConnectorProfileProps", () => {
             },
           },
         },
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Salesforce",
         KMSArn: {
           "Fn::GetAtt": ["TestKey4CACAF33", "Arn"],

--- a/test/salesforce/source.test.ts
+++ b/test/salesforce/source.test.ts
@@ -197,7 +197,7 @@ describe("SalesforceSource", () => {
           },
         },
       },
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "Salesforce",
     });
 
@@ -217,7 +217,7 @@ describe("SalesforceSource", () => {
       FlowName: "TestStackTestFlow32CDAF42",
       SourceFlowConfig: {
         ApiVersion: "1",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Salesforce",
         SourceConnectorProperties: {
           Salesforce: {

--- a/test/slack/profile.test.ts
+++ b/test/slack/profile.test.ts
@@ -28,7 +28,7 @@ describe("SlackConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Slack",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -68,7 +68,7 @@ describe("SlackConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Slack",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -154,7 +154,7 @@ describe("SlackConnectorProfile", () => {
     Template.fromStack(stack).hasResource("AWS::AppFlow::ConnectorProfile", {
       Properties: {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Slack",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {

--- a/test/slack/source.test.ts
+++ b/test/slack/source.test.ts
@@ -108,7 +108,7 @@ describe("SlackSource", () => {
 
     template.hasResourceProperties("AWS::AppFlow::ConnectorProfile", {
       ConnectionMode: "Public",
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "Slack",
       ConnectorProfileConfig: {
         ConnectorProfileCredentials: {
@@ -129,7 +129,7 @@ describe("SlackSource", () => {
     template.hasResource("AWS::AppFlow::Flow", {
       Properties: {
         SourceFlowConfig: {
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "Slack",
           SourceConnectorProperties: {
             Slack: {
@@ -141,7 +141,7 @@ describe("SlackSource", () => {
       DependsOn: [
         "TestBucketPolicyBA12ED38",
         "TestBucket560B80BC",
-        "TestProfile45C36389",
+        "TestProfileBC0F4812",
       ],
     });
   });

--- a/test/zendesk/profile.test.ts
+++ b/test/zendesk/profile.test.ts
@@ -28,7 +28,7 @@ describe("ZendeskConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Zendesk",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -68,7 +68,7 @@ describe("ZendeskConnectorProfile", () => {
       "AWS::AppFlow::ConnectorProfile",
       {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Zendesk",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {
@@ -154,7 +154,7 @@ describe("ZendeskConnectorProfile", () => {
     Template.fromStack(stack).hasResource("AWS::AppFlow::ConnectorProfile", {
       Properties: {
         ConnectionMode: "Public",
-        ConnectorProfileName: "TestProfile",
+        ConnectorProfileName: "TestStackTestProfile18724107",
         ConnectorType: "Zendesk",
         ConnectorProfileConfig: {
           ConnectorProfileCredentials: {

--- a/test/zendesk/source.test.ts
+++ b/test/zendesk/source.test.ts
@@ -108,7 +108,7 @@ describe("ZendeskSource", () => {
 
     template.hasResourceProperties("AWS::AppFlow::ConnectorProfile", {
       ConnectionMode: "Public",
-      ConnectorProfileName: "TestProfile",
+      ConnectorProfileName: "TestStackTestProfile18724107",
       ConnectorType: "Zendesk",
       ConnectorProfileConfig: {
         ConnectorProfileCredentials: {
@@ -129,7 +129,7 @@ describe("ZendeskSource", () => {
     template.hasResource("AWS::AppFlow::Flow", {
       Properties: {
         SourceFlowConfig: {
-          ConnectorProfileName: "TestProfile",
+          ConnectorProfileName: "TestStackTestProfile18724107",
           ConnectorType: "Zendesk",
           SourceConnectorProperties: {
             Zendesk: {
@@ -141,7 +141,7 @@ describe("ZendeskSource", () => {
       DependsOn: [
         "TestBucketPolicyBA12ED38",
         "TestBucket560B80BC",
-        "TestProfile45C36389",
+        "TestProfileBC0F4812",
       ],
     });
   });


### PR DESCRIPTION
Fixes #392 

- Adds default name generation according to [the CFN requirements for CustomerProfile](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-appflow-connectorprofile.html#cfn-appflow-connectorprofile-connectorprofilename)
- changes the L1 construct's name of `ConnectorProfileBase` to `'Resource'` following the AWS CDK standard approach
- changes the L1 construct's name of `FlowBase` to `'Resource'` following the AWS CDK standard approach